### PR TITLE
Implement EventSub chat settings and message handling features

### DIFF
--- a/CatCore/CatCore.csproj
+++ b/CatCore/CatCore.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<OutputType>library</OutputType>
-		<LangVersion>9</LangVersion>
+		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/CatCore/CatCore.csproj
+++ b/CatCore/CatCore.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<OutputType>library</OutputType>
-		<LangVersion>latest</LangVersion>
+		<LangVersion>11.0</LangVersion>
 		<Nullable>enable</Nullable>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/CatCore/CatCoreInstance.cs
+++ b/CatCore/CatCoreInstance.cs
@@ -134,14 +134,13 @@ namespace CatCore
 			container.Register<ITwitchAuthService, TwitchAuthService>(Reuse.Singleton);
 			container.Register<ITwitchChannelManagementService, TwitchChannelManagementService>(Reuse.Singleton, Made.Of(FactoryMethod.ConstructorWithResolvableArgumentsIncludingNonPublic));
 			container.RegisterMany(new[] { typeof(ITwitchHelixApiService), typeof(TwitchHelixApiService) }, typeof(TwitchHelixApiService), Reuse.Singleton, Made.Of(FactoryMethod.ConstructorWithResolvableArgumentsIncludingNonPublic));
-			container.Register<ITwitchPubSubServiceManager, TwitchPubSubServiceManager>(Reuse.Singleton);
+			container.RegisterMany(new[] { typeof(ITwitchIrcService), typeof(ITwitchPubSubServiceManager) }, typeof(TwitchEventSubChatService), Reuse.Singleton);
 			container.Register<ITwitchRoomStateTrackerService, TwitchRoomStateTrackerService>(Reuse.Singleton, Made.Of(FactoryMethod.ConstructorWithResolvableArgumentsIncludingNonPublic));
 			container.Register<ITwitchUserStateTrackerService, TwitchUserStateTrackerService>(Reuse.Singleton, Made.Of(FactoryMethod.ConstructorWithResolvableArgumentsIncludingNonPublic));
 			container.Register<TwitchBadgeDataProvider>(Reuse.Singleton);
 			container.Register<TwitchCheermoteDataProvider>(Reuse.Singleton);
 			container.Register<TwitchMediaDataProvider>(Reuse.Singleton);
 			container.Register<TwitchEmoteDetectionHelper>(Reuse.Singleton);
-			container.Register<ITwitchIrcService, TwitchEventSubChatService>(Reuse.Singleton);
 
 			container.RegisterMany(new[] { typeof(IPlatformService<ITwitchService, TwitchChannel, TwitchMessage>), typeof(ITwitchService) }, typeof(TwitchService), Reuse.Singleton,
 				Made.Of(FactoryMethod.ConstructorWithResolvableArgumentsIncludingNonPublic));

--- a/CatCore/CatCoreInstance.cs
+++ b/CatCore/CatCoreInstance.cs
@@ -79,10 +79,6 @@ namespace CatCore
 			Log.Logger = new LoggerConfiguration()
 				.MinimumLevel.Verbose()
 				.Enrich.FromLogContext()
-#if DEBUG
-				.WriteTo.Async(writeTo => writeTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss.fff} {Level:u3} {SourceContext:l}] {Message:lj}{NewLine}{Exception}",
-					theme: Serilog.Sinks.SystemConsole.Themes.SystemConsoleTheme.Colored))
-#endif
 				.WriteTo.Conditional(_ => OnLogReceived != null, writeTo => writeTo.Async(
 					writeToInternal => writeToInternal.Actionable(evt =>
 					{
@@ -137,7 +133,7 @@ namespace CatCore
 			// Register Twitch-specific services
 			container.Register<ITwitchAuthService, TwitchAuthService>(Reuse.Singleton);
 			container.Register<ITwitchChannelManagementService, TwitchChannelManagementService>(Reuse.Singleton, Made.Of(FactoryMethod.ConstructorWithResolvableArgumentsIncludingNonPublic));
-			container.Register<ITwitchHelixApiService, TwitchHelixApiService>(Reuse.Singleton, Made.Of(FactoryMethod.ConstructorWithResolvableArgumentsIncludingNonPublic));
+			container.RegisterMany(new[] { typeof(ITwitchHelixApiService), typeof(TwitchHelixApiService) }, typeof(TwitchHelixApiService), Reuse.Singleton, Made.Of(FactoryMethod.ConstructorWithResolvableArgumentsIncludingNonPublic));
 			container.Register<ITwitchPubSubServiceManager, TwitchPubSubServiceManager>(Reuse.Singleton);
 			container.Register<ITwitchRoomStateTrackerService, TwitchRoomStateTrackerService>(Reuse.Singleton, Made.Of(FactoryMethod.ConstructorWithResolvableArgumentsIncludingNonPublic));
 			container.Register<ITwitchUserStateTrackerService, TwitchUserStateTrackerService>(Reuse.Singleton, Made.Of(FactoryMethod.ConstructorWithResolvableArgumentsIncludingNonPublic));
@@ -145,7 +141,7 @@ namespace CatCore
 			container.Register<TwitchCheermoteDataProvider>(Reuse.Singleton);
 			container.Register<TwitchMediaDataProvider>(Reuse.Singleton);
 			container.Register<TwitchEmoteDetectionHelper>(Reuse.Singleton);
-			container.Register<ITwitchIrcService, TwitchIrcService>(Reuse.Singleton);
+			container.Register<ITwitchIrcService, TwitchEventSubChatService>(Reuse.Singleton);
 
 			container.RegisterMany(new[] { typeof(IPlatformService<ITwitchService, TwitchChannel, TwitchMessage>), typeof(ITwitchService) }, typeof(TwitchService), Reuse.Singleton,
 				Made.Of(FactoryMethod.ConstructorWithResolvableArgumentsIncludingNonPublic));

--- a/CatCore/Helpers/IsExternalInit.cs
+++ b/CatCore/Helpers/IsExternalInit.cs
@@ -1,0 +1,11 @@
+namespace System.Runtime.CompilerServices
+{
+	/// <summary>
+	/// Polyfill for IsExternalInit to support init accessors in .NET Standard 2.0+
+	/// </summary>
+	[System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Struct | System.AttributeTargets.Field | System.AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+	internal sealed class IsExternalInit : System.Attribute
+	{
+	}
+}
+

--- a/CatCore/Helpers/JSON/TwitchEventSubSerializerContext.cs
+++ b/CatCore/Helpers/JSON/TwitchEventSubSerializerContext.cs
@@ -1,0 +1,44 @@
+using System.Text.Json.Serialization;
+using CatCore.Models.Twitch.EventSub;
+
+namespace CatCore.Helpers.JSON
+{
+	[JsonSerializable(typeof(EventSubWebSocketMessage<EventSubSessionPayload>))]
+	[JsonSerializable(typeof(EventSubSessionPayload))]
+	[JsonSerializable(typeof(EventSubSessionInfo))]
+	[JsonSerializable(typeof(EventSubWebSocketMessage<EventSubChatMessagePayload>))]
+	[JsonSerializable(typeof(EventSubChatMessagePayload))]
+	[JsonSerializable(typeof(EventSubSubscription))]
+	[JsonSerializable(typeof(EventSubChatMessageEvent))]
+	[JsonSerializable(typeof(EventSubChatMessageContent))]
+	[JsonSerializable(typeof(EventSubFragment))]
+	[JsonSerializable(typeof(EventSubEmoteFragment))]
+	[JsonSerializable(typeof(EventSubCheermoteFragment))]
+	[JsonSerializable(typeof(EventSubMentionFragment))]
+	[JsonSerializable(typeof(EventSubBadge))]
+	[JsonSerializable(typeof(EventSubCheer))]
+	[JsonSerializable(typeof(EventSubReply))]
+	[JsonSerializable(typeof(EventSubWebSocketMessage<EventSubChatNotificationPayload>))]
+	[JsonSerializable(typeof(EventSubChatNotificationPayload))]
+	[JsonSerializable(typeof(EventSubChatNotificationEvent))]
+	[JsonSerializable(typeof(EventSubNotificationSub))]
+	[JsonSerializable(typeof(EventSubNotificationResub))]
+	[JsonSerializable(typeof(EventSubNotificationGiftSub))]
+	[JsonSerializable(typeof(EventSubNotificationRaid))]
+	[JsonSerializable(typeof(EventSubNotificationUnraid))]
+	[JsonSerializable(typeof(EventSubNotificationPayItForward))]
+	[JsonSerializable(typeof(EventSubNotificationAnnouncement))]
+	[JsonSerializable(typeof(EventSubNotificationBitsBadgeTier))]
+	[JsonSerializable(typeof(EventSubWebSocketMessage<EventSubChatMessageDeletePayload>))]
+	[JsonSerializable(typeof(EventSubChatMessageDeletePayload))]
+	[JsonSerializable(typeof(EventSubChatMessageDeleteEvent))]
+	[JsonSerializable(typeof(EventSubWebSocketMessage<EventSubChatClearPayload>))]
+	[JsonSerializable(typeof(EventSubChatClearPayload))]
+	[JsonSerializable(typeof(EventSubChatClearEvent))]
+	[JsonSerializable(typeof(EventSubWebSocketMessage<EventSubChatSettingsPayload>))]
+	[JsonSerializable(typeof(EventSubChatSettingsPayload))]
+	[JsonSerializable(typeof(EventSubChatSettingsEvent))]
+	internal partial class TwitchEventSubSerializerContext : JsonSerializerContext
+	{
+	}
+}

--- a/CatCore/Helpers/JSON/TwitchHelixSerializerContext.cs
+++ b/CatCore/Helpers/JSON/TwitchHelixSerializerContext.cs
@@ -36,8 +36,8 @@ namespace CatCore.Helpers.JSON
 	[JsonSerializable(typeof(HelixRequests.SendChatMessageRequestDto))]
 	[JsonSerializable(typeof(HelixRequests.EventSubSubscriptionRequestDto))]
 	[JsonSerializable(typeof(HelixRequests.EventSubTransportDto))]
-	[JsonSerializable(typeof(HelixRequests.EventSubSubscriptionResponseDto))]
-	[JsonSerializable(typeof(HelixRequests.EventSubSubscriptionInfoDto))]
+	[JsonSerializable(typeof(HelixResponses.EventSubSubscriptionResponseDto))]
+	[JsonSerializable(typeof(HelixResponses.EventSubSubscriptionInfoDto))]
 	internal partial class TwitchHelixSerializerContext : JsonSerializerContext
 	{
 	}

--- a/CatCore/Helpers/JSON/TwitchHelixSerializerContext.cs
+++ b/CatCore/Helpers/JSON/TwitchHelixSerializerContext.cs
@@ -33,6 +33,11 @@ namespace CatCore.Helpers.JSON
 	[JsonSerializable(typeof(HelixRequests.SendChatAnnouncementRequestDto))]
 	[JsonSerializable(typeof(HelixResponses.ResponseBase<HelixResponses.UserChatColorData>))]
 	[JsonSerializable(typeof(HelixResponses.ResponseBase<HelixResponses.StartRaidData>))]
+	[JsonSerializable(typeof(HelixRequests.SendChatMessageRequestDto))]
+	[JsonSerializable(typeof(HelixRequests.EventSubSubscriptionRequestDto))]
+	[JsonSerializable(typeof(HelixRequests.EventSubTransportDto))]
+	[JsonSerializable(typeof(HelixRequests.EventSubSubscriptionResponseDto))]
+	[JsonSerializable(typeof(HelixRequests.EventSubSubscriptionInfoDto))]
 	internal partial class TwitchHelixSerializerContext : JsonSerializerContext
 	{
 	}

--- a/CatCore/Models/Twitch/EventSub/EventSubChatClearPayload.cs
+++ b/CatCore/Models/Twitch/EventSub/EventSubChatClearPayload.cs
@@ -1,0 +1,34 @@
+using System.Text.Json.Serialization;
+
+namespace CatCore.Models.Twitch.EventSub
+{
+	internal record struct EventSubChatClearPayload
+	{
+		[JsonPropertyName("subscription")]
+		public EventSubSubscription Subscription { get; init; }
+
+		[JsonPropertyName("event")]
+		public EventSubChatClearEvent Event { get; init; }
+	}
+
+	public record struct EventSubChatClearEvent
+	{
+		[JsonPropertyName("broadcaster_user_id")]
+		public string BroadcasterUserId { get; init; }
+
+		[JsonPropertyName("broadcaster_user_login")]
+		public string BroadcasterUserLogin { get; init; }
+
+		[JsonPropertyName("broadcaster_user_name")]
+		public string BroadcasterUserName { get; init; }
+
+		[JsonPropertyName("moderator_user_id")]
+		public string ModeratorUserId { get; init; }
+
+		[JsonPropertyName("moderator_user_login")]
+		public string ModeratorUserLogin { get; init; }
+
+		[JsonPropertyName("moderator_user_name")]
+		public string ModeratorUserName { get; init; }
+	}
+}

--- a/CatCore/Models/Twitch/EventSub/EventSubChatMessageDeletePayload.cs
+++ b/CatCore/Models/Twitch/EventSub/EventSubChatMessageDeletePayload.cs
@@ -1,0 +1,37 @@
+using System.Text.Json.Serialization;
+
+namespace CatCore.Models.Twitch.EventSub
+{
+	internal record struct EventSubChatMessageDeletePayload
+	{
+		[JsonPropertyName("subscription")]
+		public EventSubSubscription Subscription { get; init; }
+
+		[JsonPropertyName("event")]
+		public EventSubChatMessageDeleteEvent Event { get; init; }
+	}
+
+	public record struct EventSubChatMessageDeleteEvent
+	{
+		[JsonPropertyName("broadcaster_user_id")]
+		public string BroadcasterUserId { get; init; }
+
+		[JsonPropertyName("broadcaster_user_login")]
+		public string BroadcasterUserLogin { get; init; }
+
+		[JsonPropertyName("broadcaster_user_name")]
+		public string BroadcasterUserName { get; init; }
+
+		[JsonPropertyName("target_user_id")]
+		public string TargetUserId { get; init; }
+
+		[JsonPropertyName("target_user_login")]
+		public string TargetUserLogin { get; init; }
+
+		[JsonPropertyName("target_user_name")]
+		public string TargetUserName { get; init; }
+
+		[JsonPropertyName("message_id")]
+		public string MessageId { get; init; }
+	}
+}

--- a/CatCore/Models/Twitch/EventSub/EventSubChatMessagePayload.cs
+++ b/CatCore/Models/Twitch/EventSub/EventSubChatMessagePayload.cs
@@ -1,0 +1,196 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using JetBrains.Annotations;
+
+namespace CatCore.Models.Twitch.EventSub
+{
+	internal record struct EventSubChatMessagePayload
+	{
+		[JsonPropertyName("subscription")]
+		public EventSubSubscription Subscription { get; init; }
+
+		[JsonPropertyName("event")]
+		public EventSubChatMessageEvent Event { get; init; }
+	}
+
+	[PublicAPI]
+	public record struct EventSubSubscription
+	{
+		[JsonPropertyName("id")]
+		public string Id { get; init; }
+
+		[JsonPropertyName("type")]
+		public string Type { get; init; }
+
+		[JsonPropertyName("version")]
+		public string Version { get; init; }
+
+		[JsonPropertyName("status")]
+		public string Status { get; init; }
+
+		[JsonPropertyName("condition")]
+		public Dictionary<string, string> Condition { get; init; }
+
+		[JsonPropertyName("transport")]
+		public Dictionary<string, string> Transport { get; init; }
+
+		[JsonPropertyName("created_at")]
+		public string CreatedAt { get; init; }
+
+		[JsonPropertyName("cost")]
+		public int Cost { get; init; }
+	}
+
+	[PublicAPI]
+	public record struct EventSubChatMessageEvent
+	{
+		[JsonPropertyName("broadcaster_user_id")]
+		public string BroadcasterUserId { get; init; }
+
+		[JsonPropertyName("broadcaster_user_login")]
+		public string BroadcasterUserLogin { get; init; }
+
+		[JsonPropertyName("broadcaster_user_name")]
+		public string BroadcasterUserName { get; init; }
+
+		[JsonPropertyName("chatter_user_id")]
+		public string ChatterUserId { get; init; }
+
+		[JsonPropertyName("chatter_user_login")]
+		public string ChatterUserLogin { get; init; }
+
+		[JsonPropertyName("chatter_user_name")]
+		public string ChatterUserName { get; init; }
+
+		[JsonPropertyName("message_id")]
+		public string MessageId { get; init; }
+
+		[JsonPropertyName("message")]
+		public EventSubChatMessageContent Message { get; init; }
+
+		[JsonPropertyName("color")]
+		public string Color { get; init; }
+
+		[JsonPropertyName("badges")]
+		public List<EventSubBadge> Badges { get; init; }
+
+		[JsonPropertyName("message_type")]
+		public string MessageType { get; init; }
+
+		[JsonPropertyName("cheer")]
+		public EventSubCheer? Cheer { get; init; }
+
+		[JsonPropertyName("reply")]
+		public EventSubReply? Reply { get; init; }
+
+		[JsonPropertyName("channel_points_custom_reward_id")]
+		public string? ChannelPointsCustomRewardId { get; init; }
+	}
+
+	[PublicAPI]
+	public record struct EventSubChatMessageContent
+	{
+		[JsonPropertyName("text")]
+		public string Text { get; init; }
+
+		[JsonPropertyName("fragments")]
+		public List<EventSubFragment> Fragments { get; init; }
+	}
+
+	[PublicAPI]
+	public record struct EventSubFragment
+	{
+		[JsonPropertyName("type")]
+		public string Type { get; init; }
+
+		[JsonPropertyName("text")]
+		public string Text { get; init; }
+
+		[JsonPropertyName("emote")]
+		public EventSubEmoteFragment? Emote { get; init; }
+
+		[JsonPropertyName("cheermote")]
+		public EventSubCheermoteFragment? Cheermote { get; init; }
+
+		[JsonPropertyName("mention")]
+		public EventSubMentionFragment? Mention { get; init; }
+	}
+
+	[PublicAPI]
+	public record struct EventSubEmoteFragment
+	{
+		[JsonPropertyName("id")]
+		public string Id { get; init; }
+
+		[JsonPropertyName("emote_set_id")]
+		public string EmoteSetId { get; init; }
+
+		[JsonPropertyName("owner_id")]
+		public string OwnerId { get; init; }
+
+		[JsonPropertyName("format")]
+		public List<string> Format { get; init; }
+	}
+
+	[PublicAPI]
+	public record struct EventSubCheermoteFragment
+	{
+		[JsonPropertyName("bits")]
+		public int Bits { get; init; }
+
+		[JsonPropertyName("tier")]
+		public int Tier { get; init; }
+	}
+
+	[PublicAPI]
+	public record struct EventSubMentionFragment
+	{
+		[JsonPropertyName("user_id")]
+		public string UserId { get; init; }
+
+		[JsonPropertyName("user_name")]
+		public string UserName { get; init; }
+
+		[JsonPropertyName("user_login")]
+		public string UserLogin { get; init; }
+	}
+
+	[PublicAPI]
+	public record struct EventSubBadge
+	{
+		[JsonPropertyName("set_id")]
+		public string SetId { get; init; }
+
+		[JsonPropertyName("id")]
+		public string Id { get; init; }
+
+		[JsonPropertyName("info")]
+		public string Info { get; init; }
+	}
+
+	[PublicAPI]
+	public record struct EventSubCheer
+	{
+		[JsonPropertyName("bits")]
+		public int Bits { get; init; }
+	}
+
+	[PublicAPI]
+	public record struct EventSubReply
+	{
+		[JsonPropertyName("parent_message_id")]
+		public string ParentMessageId { get; init; }
+
+		[JsonPropertyName("parent_message_body")]
+		public string ParentMessageBody { get; init; }
+
+		[JsonPropertyName("parent_user_id")]
+		public string ParentUserId { get; init; }
+
+		[JsonPropertyName("parent_user_login")]
+		public string ParentUserLogin { get; init; }
+
+		[JsonPropertyName("parent_user_name")]
+		public string ParentUserName { get; init; }
+	}
+}

--- a/CatCore/Models/Twitch/EventSub/EventSubChatNotificationPayload.cs
+++ b/CatCore/Models/Twitch/EventSub/EventSubChatNotificationPayload.cs
@@ -1,0 +1,172 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using JetBrains.Annotations;
+
+namespace CatCore.Models.Twitch.EventSub
+{
+	internal record struct EventSubChatNotificationPayload
+	{
+		[JsonPropertyName("subscription")]
+		public EventSubSubscription Subscription { get; init; }
+
+		[JsonPropertyName("event")]
+		public EventSubChatNotificationEvent Event { get; init; }
+	}
+
+	[PublicAPI]
+	public record struct EventSubChatNotificationEvent
+	{
+		[JsonPropertyName("broadcaster_user_id")]
+		public string BroadcasterUserId { get; init; }
+
+		[JsonPropertyName("broadcaster_user_login")]
+		public string BroadcasterUserLogin { get; init; }
+
+		[JsonPropertyName("broadcaster_user_name")]
+		public string BroadcasterUserName { get; init; }
+
+		[JsonPropertyName("chatter_user_id")]
+		public string ChatterUserId { get; init; }
+
+		[JsonPropertyName("chatter_user_login")]
+		public string ChatterUserLogin { get; init; }
+
+		[JsonPropertyName("chatter_user_name")]
+		public string ChatterUserName { get; init; }
+
+		[JsonPropertyName("notice_type")]
+		public string NoticeType { get; init; }
+
+		[JsonPropertyName("message")]
+		public EventSubChatMessageContent Message { get; init; }
+
+		[JsonPropertyName("sub")]
+		public EventSubNotificationSub? Sub { get; init; }
+
+		[JsonPropertyName("resub")]
+		public EventSubNotificationResub? Resub { get; init; }
+
+		[JsonPropertyName("gift_sub")]
+		public EventSubNotificationGiftSub? GiftSub { get; init; }
+
+		[JsonPropertyName("raid")]
+		public EventSubNotificationRaid? Raid { get; init; }
+
+		[JsonPropertyName("unraid")]
+		public EventSubNotificationUnraid? Unraid { get; init; }
+
+		[JsonPropertyName("pay_it_forward")]
+		public EventSubNotificationPayItForward? PayItForward { get; init; }
+
+		[JsonPropertyName("announcement")]
+		public EventSubNotificationAnnouncement? Announcement { get; init; }
+
+		[JsonPropertyName("bits_badge_tier")]
+		public EventSubNotificationBitsBadgeTier? BitsBadgeTier { get; init; }
+	}
+
+	[PublicAPI]
+	public record struct EventSubNotificationSub
+	{
+		[JsonPropertyName("is_gift")]
+		public bool IsGift { get; init; }
+
+		[JsonPropertyName("sub_tier")]
+		public string SubTier { get; init; }
+
+		[JsonPropertyName("duration_months")]
+		public int DurationMonths { get; init; }
+	}
+
+	[PublicAPI]
+	public record struct EventSubNotificationResub
+	{
+		[JsonPropertyName("duration_months")]
+		public int DurationMonths { get; init; }
+
+		[JsonPropertyName("cumulative_months")]
+		public int CumulativeMonths { get; init; }
+
+		[JsonPropertyName("streak_months")]
+		public int? StreakMonths { get; init; }
+
+		[JsonPropertyName("is_streak")]
+		public bool IsStreak { get; init; }
+
+		[JsonPropertyName("sub_tier")]
+		public string SubTier { get; init; }
+	}
+
+	[PublicAPI]
+	public record struct EventSubNotificationGiftSub
+	{
+		[JsonPropertyName("community_gift_id")]
+		public string? CommunityGiftId { get; init; }
+
+		[JsonPropertyName("duration_months")]
+		public int DurationMonths { get; init; }
+
+		[JsonPropertyName("cumulative_total")]
+		public int? CumulativeTotal { get; init; }
+
+		[JsonPropertyName("recipient_user_id")]
+		public string RecipientUserId { get; init; }
+
+		[JsonPropertyName("recipient_user_login")]
+		public string RecipientUserLogin { get; init; }
+
+		[JsonPropertyName("recipient_user_name")]
+		public string RecipientUserName { get; init; }
+
+		[JsonPropertyName("sub_tier")]
+		public string SubTier { get; init; }
+
+		[JsonPropertyName("community_gift_ids")]
+		public List<string>? CommunityGiftIds { get; init; }
+	}
+
+	[PublicAPI]
+	public record struct EventSubNotificationRaid
+	{
+		[JsonPropertyName("user_id")]
+		public string UserId { get; init; }
+
+		[JsonPropertyName("user_login")]
+		public string UserLogin { get; init; }
+
+		[JsonPropertyName("user_name")]
+		public string UserName { get; init; }
+
+		[JsonPropertyName("viewer_count")]
+		public int ViewerCount { get; init; }
+	}
+
+	[PublicAPI]
+	public record struct EventSubNotificationUnraid
+	{
+	}
+
+	[PublicAPI]
+	public record struct EventSubNotificationPayItForward
+	{
+		[JsonPropertyName("is_anonymous")]
+		public bool IsAnonymous { get; init; }
+
+		[JsonPropertyName("community_gift_id")]
+		public string? CommunityGiftId { get; init; }
+	}
+
+	[PublicAPI]
+	public record struct EventSubNotificationAnnouncement
+	{
+		[JsonPropertyName("color")]
+		public string Color { get; init; }
+	}
+
+	[PublicAPI]
+	public record struct EventSubNotificationBitsBadgeTier
+	{
+		[JsonPropertyName("tier")]
+		public int Tier { get; init; }
+	}
+}

--- a/CatCore/Models/Twitch/EventSub/EventSubChatNotificationPayload.cs
+++ b/CatCore/Models/Twitch/EventSub/EventSubChatNotificationPayload.cs
@@ -40,6 +40,9 @@ namespace CatCore.Models.Twitch.EventSub
 		[JsonPropertyName("message")]
 		public EventSubChatMessageContent Message { get; init; }
 
+		[JsonPropertyName("system_message")]
+		public string? SystemMessage { get; init; }
+
 		[JsonPropertyName("sub")]
 		public EventSubNotificationSub? Sub { get; init; }
 

--- a/CatCore/Models/Twitch/EventSub/EventSubChatSettingsPayload.cs
+++ b/CatCore/Models/Twitch/EventSub/EventSubChatSettingsPayload.cs
@@ -1,0 +1,46 @@
+using System.Text.Json.Serialization;
+
+namespace CatCore.Models.Twitch.EventSub
+{
+	internal record struct EventSubChatSettingsPayload
+	{
+		[JsonPropertyName("subscription")]
+		public EventSubSubscription Subscription { get; init; }
+
+		[JsonPropertyName("event")]
+		public EventSubChatSettingsEvent Event { get; init; }
+	}
+
+	public record struct EventSubChatSettingsEvent
+	{
+		[JsonPropertyName("broadcaster_user_id")]
+		public string BroadcasterUserId { get; init; }
+
+		[JsonPropertyName("broadcaster_user_login")]
+		public string BroadcasterUserLogin { get; init; }
+
+		[JsonPropertyName("broadcaster_user_name")]
+		public string BroadcasterUserName { get; init; }
+
+		[JsonPropertyName("emote_mode")]
+		public bool EmoteMode { get; init; }
+
+		[JsonPropertyName("follower_mode")]
+		public bool FollowerMode { get; init; }
+
+		[JsonPropertyName("follower_mode_duration_minutes")]
+		public int FollowerModeDurationMinutes { get; init; }
+
+		[JsonPropertyName("slow_mode")]
+		public bool SlowMode { get; init; }
+
+		[JsonPropertyName("slow_mode_wait_seconds")]
+		public int SlowModeWaitSeconds { get; init; }
+
+		[JsonPropertyName("subscriber_mode")]
+		public bool SubscriberMode { get; init; }
+
+		[JsonPropertyName("unique_chat_mode")]
+		public bool UniqueChatMode { get; init; }
+	}
+}

--- a/CatCore/Models/Twitch/EventSub/EventSubSessionPayload.cs
+++ b/CatCore/Models/Twitch/EventSub/EventSubSessionPayload.cs
@@ -1,0 +1,30 @@
+using System.Text.Json.Serialization;
+using JetBrains.Annotations;
+
+namespace CatCore.Models.Twitch.EventSub
+{
+	internal record struct EventSubSessionPayload
+	{
+		[JsonPropertyName("session")]
+		public EventSubSessionInfo Session { get; init; }
+	}
+
+	[PublicAPI]
+	public record struct EventSubSessionInfo
+	{
+		[JsonPropertyName("id")]
+		public string Id { get; init; }
+
+		[JsonPropertyName("status")]
+		public string Status { get; init; }
+
+		[JsonPropertyName("keepalive_timeout_seconds")]
+		public int KeepaliveTimeoutSeconds { get; init; }
+
+		[JsonPropertyName("reconnect_url")]
+		public string? ReconnectUrl { get; init; }
+
+		[JsonPropertyName("created_at")]
+		public string CreatedAt { get; init; }
+	}
+}

--- a/CatCore/Models/Twitch/EventSub/EventSubWebSocketMessage.cs
+++ b/CatCore/Models/Twitch/EventSub/EventSubWebSocketMessage.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace CatCore.Models.Twitch.EventSub
+{
+	internal record struct EventSubMetadata
+	{
+		[JsonPropertyName("message_id")]
+		public string MessageId { get; init; }
+
+		[JsonPropertyName("message_type")]
+		public string MessageType { get; init; }
+
+		[JsonPropertyName("message_timestamp")]
+		public DateTime MessageTimestamp { get; init; }
+
+		[JsonPropertyName("subscription_type")]
+		public string SubscriptionType { get; init; }
+
+		[JsonPropertyName("subscription_version")]
+		public string SubscriptionVersion { get; init; }
+	}
+
+	internal record struct EventSubWebSocketMessage<TPayload> where TPayload : struct
+	{
+		[JsonPropertyName("metadata")]
+		public EventSubMetadata Metadata { get; init; }
+
+		[JsonPropertyName("payload")]
+		public TPayload Payload { get; init; }
+	}
+}

--- a/CatCore/Models/Twitch/Helix/Requests/EventSubRequestDtos.cs
+++ b/CatCore/Models/Twitch/Helix/Requests/EventSubRequestDtos.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using JetBrains.Annotations;
+
+namespace CatCore.Models.Twitch.Helix.Requests
+{
+	[PublicAPI]
+	internal record struct SendChatMessageRequestDto
+	{
+		[JsonPropertyName("broadcaster_id")]
+		public string BroadcasterId { get; init; }
+
+		[JsonPropertyName("sender_id")]
+		public string SenderId { get; init; }
+
+		[JsonPropertyName("message")]
+		public string Message { get; init; }
+
+		[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+		[JsonPropertyName("reply_parent_message_id")]
+		public string? ReplyParentMessageId { get; init; }
+	}
+
+	[PublicAPI]
+	internal record struct EventSubSubscriptionRequestDto
+	{
+		[JsonPropertyName("type")]
+		public string Type { get; init; }
+
+		[JsonPropertyName("version")]
+		public string Version { get; init; }
+
+		[JsonPropertyName("condition")]
+		public Dictionary<string, string> Condition { get; init; }
+
+		[JsonPropertyName("transport")]
+		public EventSubTransportDto Transport { get; init; }
+	}
+
+	[PublicAPI]
+	internal record struct EventSubTransportDto
+	{
+		[JsonPropertyName("method")]
+		public string Method { get; init; }
+
+		[JsonPropertyName("session_id")]
+		public string SessionId { get; init; }
+	}
+
+	[PublicAPI]
+	internal record struct EventSubSubscriptionResponseDto
+	{
+		[JsonPropertyName("data")]
+		public List<EventSubSubscriptionInfoDto> Data { get; init; }
+
+		[JsonPropertyName("total")]
+		public int Total { get; init; }
+
+		[JsonPropertyName("total_cost")]
+		public int TotalCost { get; init; }
+
+		[JsonPropertyName("max_total_cost")]
+		public int MaxTotalCost { get; init; }
+
+		[JsonPropertyName("pagination")]
+		public Dictionary<string, string>? Pagination { get; init; }
+	}
+
+	[PublicAPI]
+	internal record struct EventSubSubscriptionInfoDto
+	{
+		[JsonPropertyName("id")]
+		public string Id { get; init; }
+
+		[JsonPropertyName("type")]
+		public string Type { get; init; }
+
+		[JsonPropertyName("version")]
+		public string Version { get; init; }
+
+		[JsonPropertyName("status")]
+		public string Status { get; init; }
+
+		[JsonPropertyName("condition")]
+		public Dictionary<string, string> Condition { get; init; }
+
+		[JsonPropertyName("transport")]
+		public Dictionary<string, string> Transport { get; init; }
+
+		[JsonPropertyName("created_at")]
+		public DateTime CreatedAt { get; init; }
+
+		[JsonPropertyName("cost")]
+		public int Cost { get; init; }
+	}
+}

--- a/CatCore/Models/Twitch/Helix/Requests/EventSubRequestDtos.cs
+++ b/CatCore/Models/Twitch/Helix/Requests/EventSubRequestDtos.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using JetBrains.Annotations;
@@ -47,51 +46,5 @@ namespace CatCore.Models.Twitch.Helix.Requests
 		[JsonPropertyName("session_id")]
 		public string SessionId { get; init; }
 	}
-
-	[PublicAPI]
-	internal record struct EventSubSubscriptionResponseDto
-	{
-		[JsonPropertyName("data")]
-		public List<EventSubSubscriptionInfoDto> Data { get; init; }
-
-		[JsonPropertyName("total")]
-		public int Total { get; init; }
-
-		[JsonPropertyName("total_cost")]
-		public int TotalCost { get; init; }
-
-		[JsonPropertyName("max_total_cost")]
-		public int MaxTotalCost { get; init; }
-
-		[JsonPropertyName("pagination")]
-		public Dictionary<string, string>? Pagination { get; init; }
-	}
-
-	[PublicAPI]
-	internal record struct EventSubSubscriptionInfoDto
-	{
-		[JsonPropertyName("id")]
-		public string Id { get; init; }
-
-		[JsonPropertyName("type")]
-		public string Type { get; init; }
-
-		[JsonPropertyName("version")]
-		public string Version { get; init; }
-
-		[JsonPropertyName("status")]
-		public string Status { get; init; }
-
-		[JsonPropertyName("condition")]
-		public Dictionary<string, string> Condition { get; init; }
-
-		[JsonPropertyName("transport")]
-		public Dictionary<string, string> Transport { get; init; }
-
-		[JsonPropertyName("created_at")]
-		public DateTime CreatedAt { get; init; }
-
-		[JsonPropertyName("cost")]
-		public int Cost { get; init; }
-	}
 }
+

--- a/CatCore/Models/Twitch/Helix/Responses/EventSubResponseDtos.cs
+++ b/CatCore/Models/Twitch/Helix/Responses/EventSubResponseDtos.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using JetBrains.Annotations;
+
+namespace CatCore.Models.Twitch.Helix.Responses
+{
+	[PublicAPI]
+	internal record struct EventSubSubscriptionResponseDto
+	{
+		[JsonPropertyName("data")]
+		public List<EventSubSubscriptionInfoDto> Data { get; init; }
+
+		[JsonPropertyName("total")]
+		public int Total { get; init; }
+
+		[JsonPropertyName("total_cost")]
+		public int TotalCost { get; init; }
+
+		[JsonPropertyName("max_total_cost")]
+		public int MaxTotalCost { get; init; }
+
+		[JsonPropertyName("pagination")]
+		public Dictionary<string, string>? Pagination { get; init; }
+	}
+
+	[PublicAPI]
+	internal record struct EventSubSubscriptionInfoDto
+	{
+		[JsonPropertyName("id")]
+		public string Id { get; init; }
+
+		[JsonPropertyName("type")]
+		public string Type { get; init; }
+
+		[JsonPropertyName("version")]
+		public string Version { get; init; }
+
+		[JsonPropertyName("status")]
+		public string Status { get; init; }
+
+		[JsonPropertyName("condition")]
+		public Dictionary<string, string> Condition { get; init; }
+
+		[JsonPropertyName("transport")]
+		public Dictionary<string, string> Transport { get; init; }
+
+		[JsonPropertyName("created_at")]
+		public DateTime CreatedAt { get; init; }
+
+		[JsonPropertyName("cost")]
+		public int Cost { get; init; }
+	}
+}

--- a/CatCore/Models/Twitch/Helix/Responses/EventSubResponseDtos.cs
+++ b/CatCore/Models/Twitch/Helix/Responses/EventSubResponseDtos.cs
@@ -6,49 +6,85 @@ using JetBrains.Annotations;
 namespace CatCore.Models.Twitch.Helix.Responses
 {
 	[PublicAPI]
-	internal record struct EventSubSubscriptionResponseDto
+	internal readonly struct EventSubSubscriptionResponseDto
 	{
+		[JsonConstructor]
+		public EventSubSubscriptionResponseDto(
+			List<EventSubSubscriptionInfoDto> data,
+			int total,
+			int totalCost,
+			int maxTotalCost,
+			Dictionary<string, string>? pagination)
+		{
+			Data = data ?? new List<EventSubSubscriptionInfoDto>();
+			Total = total;
+			TotalCost = totalCost;
+			MaxTotalCost = maxTotalCost;
+			Pagination = pagination;
+		}
+
 		[JsonPropertyName("data")]
-		public List<EventSubSubscriptionInfoDto> Data { get; init; }
+		public List<EventSubSubscriptionInfoDto> Data { get; }
 
 		[JsonPropertyName("total")]
-		public int Total { get; init; }
+		public int Total { get; }
 
 		[JsonPropertyName("total_cost")]
-		public int TotalCost { get; init; }
+		public int TotalCost { get; }
 
 		[JsonPropertyName("max_total_cost")]
-		public int MaxTotalCost { get; init; }
+		public int MaxTotalCost { get; }
 
 		[JsonPropertyName("pagination")]
-		public Dictionary<string, string>? Pagination { get; init; }
+		public Dictionary<string, string>? Pagination { get; }
 	}
 
 	[PublicAPI]
-	internal record struct EventSubSubscriptionInfoDto
+	internal readonly struct EventSubSubscriptionInfoDto
 	{
+		[JsonConstructor]
+		public EventSubSubscriptionInfoDto(
+			string id,
+			string type,
+			string version,
+			string status,
+			Dictionary<string, string> condition,
+			Dictionary<string, string> transport,
+			DateTime createdAt,
+			int cost)
+		{
+			Id = id;
+			Type = type;
+			Version = version;
+			Status = status;
+			Condition = condition ?? new Dictionary<string, string>();
+			Transport = transport ?? new Dictionary<string, string>();
+			CreatedAt = createdAt;
+			Cost = cost;
+		}
+
 		[JsonPropertyName("id")]
-		public string Id { get; init; }
+		public string Id { get; }
 
 		[JsonPropertyName("type")]
-		public string Type { get; init; }
+		public string Type { get; }
 
 		[JsonPropertyName("version")]
-		public string Version { get; init; }
+		public string Version { get; }
 
 		[JsonPropertyName("status")]
-		public string Status { get; init; }
+		public string Status { get; }
 
 		[JsonPropertyName("condition")]
-		public Dictionary<string, string> Condition { get; init; }
+		public Dictionary<string, string> Condition { get; }
 
 		[JsonPropertyName("transport")]
-		public Dictionary<string, string> Transport { get; init; }
+		public Dictionary<string, string> Transport { get; }
 
 		[JsonPropertyName("created_at")]
-		public DateTime CreatedAt { get; init; }
+		public DateTime CreatedAt { get; }
 
 		[JsonPropertyName("cost")]
-		public int Cost { get; init; }
+		public int Cost { get; }
 	}
 }

--- a/CatCore/Models/Twitch/IRC/IrcMessageTags.cs
+++ b/CatCore/Models/Twitch/IRC/IrcMessageTags.cs
@@ -54,6 +54,7 @@
 		public const string MSG_PARAM_SUB_PLAN = "msg-param-sub-plan";
 		public const string MSG_PARAM_SUB_PLAN_NAME = "msg-param-sub-plan-name";
 		public const string MSG_PARAM_VIEWER_COUNT = "msg-param-viewerCount";
+		public const string MSG_PARAM_PROFILE_IMAGE_URL = "msg-param-profileImageURL";
 		public const string MSG_PARAM_RITUAL_NAME = "msg-param-ritual-name";
 		public const string MSG_PARAM_THRESHOLD = "msg-param-threshold";
 		public const string MSG_PARAM_GIFT_MONTHS = "msg-param-gift-months";

--- a/CatCore/Services/KittenWebSocketProvider.cs
+++ b/CatCore/Services/KittenWebSocketProvider.cs
@@ -86,7 +86,7 @@ namespace CatCore.Services
 					or ConnectionStatus.Aborted
 					or ConnectionStatus.ConnectionFailed
 					or ConnectionStatus.Close)
-				.Do(_ => tcs.SetResult(null!))
+				.Do(_ => tcs.TrySetResult(null!))
 				.Subscribe();
 			_disconnectObservable = _websocketConnectionSubject
 				.Where(tuple => tuple.state is ConnectionStatus.Disconnected

--- a/CatCore/Services/Twitch/Interfaces/ITwitchPubSubServiceManager.cs
+++ b/CatCore/Services/Twitch/Interfaces/ITwitchPubSubServiceManager.cs
@@ -18,6 +18,7 @@ namespace CatCore.Services.Twitch.Interfaces
 		/// First argument of the callback is the channelId on which the event was triggered.
 		/// Second argument of the callback is additional data regarding the view count update.
 		/// </summary>
+		[Obsolete("Twitch Legacy PubSub was decommissioned. Migrate to EventSub-based APIs.")]
 		event Action<string, ViewCountUpdate> OnViewCountUpdated;
 
 		/// <summary>
@@ -25,6 +26,7 @@ namespace CatCore.Services.Twitch.Interfaces
 		/// First argument of the callback is the channelId on which the event was triggered.
 		/// Second argument of the callback is additional data regarding the StreamUp event.
 		/// </summary>
+		[Obsolete("Twitch Legacy PubSub was decommissioned. Migrate to EventSub-based APIs.")]
 		event Action<string, StreamUp> OnStreamUp;
 
 		/// <summary>
@@ -32,6 +34,7 @@ namespace CatCore.Services.Twitch.Interfaces
 		/// First argument of the callback is the channelId on which the event was triggered.
 		/// Second argument of the callback is additional data regarding the StreamDown event.
 		/// </summary>
+		[Obsolete("Twitch Legacy PubSub was decommissioned. Migrate to EventSub-based APIs.")]
 		event Action<string, StreamDown> OnStreamDown;
 
 		/// <summary>
@@ -39,6 +42,7 @@ namespace CatCore.Services.Twitch.Interfaces
 		/// First argument of the callback is the channelId on which the event was triggered.
 		/// Second argument of the callback is additional data regarding the OnCommercial event.
 		/// </summary>
+		[Obsolete("Twitch Legacy PubSub was decommissioned. Migrate to EventSub-based APIs.")]
 		event Action<string, Commercial> OnCommercial;
 
 		/// <summary>
@@ -46,6 +50,7 @@ namespace CatCore.Services.Twitch.Interfaces
 		/// First argument of the callback is the channelId on which the event was triggered.
 		/// Second argument of the callback is additional data regarding the new follower.
 		/// </summary>
+		[Obsolete("Twitch Legacy PubSub was decommissioned. Migrate to EventSub-based APIs.")]
 		event Action<string, Follow> OnFollow;
 
 		/// <summary>
@@ -53,6 +58,7 @@ namespace CatCore.Services.Twitch.Interfaces
 		/// First argument of the callback is the channelId on which the event was triggered.
 		/// Second argument of the callback is additional data regarding the poll.
 		/// </summary>
+		[Obsolete("Twitch Legacy PubSub was decommissioned. Migrate to EventSub-based APIs.")]
 		event Action<string, PollData> OnPoll;
 
 		/// <summary>
@@ -60,6 +66,7 @@ namespace CatCore.Services.Twitch.Interfaces
 		/// First argument of the callback is the channelId on which the event was triggered.
 		/// Second argument of the callback is additional data regarding the prediction.
 		/// </summary>
+		[Obsolete("Twitch Legacy PubSub was decommissioned. Migrate to EventSub-based APIs.")]
 		event Action<string, PredictionData> OnPrediction;
 
 		/// <summary>
@@ -67,6 +74,7 @@ namespace CatCore.Services.Twitch.Interfaces
 		/// First argument of the callback is the channelId on which the event was triggered.
 		/// Second argument of the callback is additional data regarding the redeemed reward and redeemer.
 		/// </summary>
+		[Obsolete("Twitch Legacy PubSub was decommissioned. Migrate to EventSub-based APIs.")]
 		event Action<string, RewardRedeemedData> OnRewardRedeemed;
 	}
 }

--- a/CatCore/Services/Twitch/Interfaces/ITwitchService.cs
+++ b/CatCore/Services/Twitch/Interfaces/ITwitchService.cs
@@ -1,3 +1,4 @@
+using System;
 using CatCore.Models.Twitch;
 using CatCore.Models.Twitch.IRC;
 using CatCore.Services.Interfaces;
@@ -12,6 +13,7 @@ namespace CatCore.Services.Twitch.Interfaces
 		/// </summary>
 		/// <returns>Returns the PubSub service manager</returns>
 		[PublicAPI]
+		[Obsolete("Twitch Legacy PubSub was decommissioned. Migrate to EventSub-based APIs.")]
 		ITwitchPubSubServiceManager GetPubSubService();
 
 		/// <summary>

--- a/CatCore/Services/Twitch/Media/TwitchEmoteDetectionHelper.cs
+++ b/CatCore/Services/Twitch/Media/TwitchEmoteDetectionHelper.cs
@@ -175,6 +175,7 @@ namespace CatCore.Services.Twitch.Media
 			// Extract Twitch emotes from fragments
 			if (twitchConfig.ParseTwitchEmotes)
 			{
+				var emoteSearchOffset = 0;
 				foreach (var fragment in fragments)
 				{
 					if (fragment.Type == "emote" && fragment.Emote.HasValue)
@@ -182,13 +183,24 @@ namespace CatCore.Services.Twitch.Media
 						var emoteFragment = fragment.Emote.Value;
 						var prefixedEmoteId = "TwitchEmote_" + emoteFragment.Id;
 
-						// Find the position of this emote text in the message
-						var startIndex = message.IndexOf(fragment.Text);
+						// Find the position of this emote text in the message, starting from the current offset
+						// to correctly handle repeated emote text appearing multiple times.
+						var startIndex = message.IndexOf(fragment.Text, emoteSearchOffset);
 						if (startIndex >= 0)
 						{
 							var endIndex = startIndex + fragment.Text.Length - 1;
 							var emoteUrl = $"https://static-cdn.jtvnw.net/emoticons/v2/{emoteFragment.Id}/static/dark/3.0";
 							emotes.Add(new TwitchEmote(prefixedEmoteId, fragment.Text, startIndex, endIndex, emoteUrl));
+							emoteSearchOffset = endIndex + 1;
+						}
+					}
+					else
+					{
+						// Advance the offset past non-emote fragments to keep position tracking accurate.
+						var fragStart = message.IndexOf(fragment.Text, emoteSearchOffset);
+						if (fragStart >= 0)
+						{
+							emoteSearchOffset = fragStart + fragment.Text.Length;
 						}
 					}
 				}
@@ -203,11 +215,18 @@ namespace CatCore.Services.Twitch.Media
 			// Extract cheermotes and custom emotes from non-emote fragments
 			if (twitchConfig.ParseCheermotes && bits > 0 || twitchConfig.ParseBttvEmotes || twitchConfig.ParseFfzEmotes)
 			{
+				var fragmentSearchOffset = 0;
 				foreach (var fragment in fragments)
 				{
+					var fragStart = message.IndexOf(fragment.Text, fragmentSearchOffset);
+					if (fragStart >= 0)
+					{
+						fragmentSearchOffset = fragStart + fragment.Text.Length;
+					}
+
 					if (fragment.Type == "text")
 					{
-						ExtractOtherEmotesFromText(emotes, fragment.Text, message, channelId, twitchConfig.ParseCheermotes && bits > 0, twitchConfig.ParseBttvEmotes || twitchConfig.ParseFfzEmotes);
+						ExtractOtherEmotesFromText(emotes, fragment.Text, message, channelId, twitchConfig.ParseCheermotes && bits > 0, twitchConfig.ParseBttvEmotes || twitchConfig.ParseFfzEmotes, fragStart >= 0 ? fragStart : 0);
 					}
 				}
 			}
@@ -215,7 +234,7 @@ namespace CatCore.Services.Twitch.Media
 			return emotes;
 		}
 
-		private void ExtractOtherEmotesFromText(List<IChatEmote> emotes, string fragmentText, string fullMessage, string channelId, bool parseCheermotes, bool parseCustomEmotes)
+		private void ExtractOtherEmotesFromText(List<IChatEmote> emotes, string fragmentText, string fullMessage, string channelId, bool parseCheermotes, bool parseCustomEmotes, int startOffset = 0)
 		{
 			if (!parseCheermotes && !parseCustomEmotes)
 			{
@@ -223,7 +242,7 @@ namespace CatCore.Services.Twitch.Media
 			}
 
 			var words = fragmentText.Split(new[] { ' ', '\t', '\n', '\r' }, System.StringSplitOptions.RemoveEmptyEntries);
-			var searchStartIndex = 0;
+			var searchStartIndex = startOffset;
 
 			foreach (var word in words)
 			{

--- a/CatCore/Services/Twitch/Media/TwitchEmoteDetectionHelper.cs
+++ b/CatCore/Services/Twitch/Media/TwitchEmoteDetectionHelper.cs
@@ -185,7 +185,7 @@ namespace CatCore.Services.Twitch.Media
 
 						// Find the position of this emote text in the message, starting from the current offset
 						// to correctly handle repeated emote text appearing multiple times.
-						var startIndex = message.IndexOf(fragment.Text, emoteSearchOffset);
+						var startIndex = message.IndexOf(fragment.Text, emoteSearchOffset, StringComparison.Ordinal);
 						if (startIndex >= 0)
 						{
 							var endIndex = startIndex + fragment.Text.Length - 1;
@@ -197,7 +197,7 @@ namespace CatCore.Services.Twitch.Media
 					else
 					{
 						// Advance the offset past non-emote fragments to keep position tracking accurate.
-						var fragStart = message.IndexOf(fragment.Text, emoteSearchOffset);
+						var fragStart = message.IndexOf(fragment.Text, emoteSearchOffset, StringComparison.Ordinal);
 						if (fragStart >= 0)
 						{
 							emoteSearchOffset = fragStart + fragment.Text.Length;
@@ -218,7 +218,7 @@ namespace CatCore.Services.Twitch.Media
 				var fragmentSearchOffset = 0;
 				foreach (var fragment in fragments)
 				{
-					var fragStart = message.IndexOf(fragment.Text, fragmentSearchOffset);
+					var fragStart = message.IndexOf(fragment.Text, fragmentSearchOffset, StringComparison.Ordinal);
 					if (fragStart >= 0)
 					{
 						fragmentSearchOffset = fragStart + fragment.Text.Length;
@@ -246,7 +246,7 @@ namespace CatCore.Services.Twitch.Media
 
 			foreach (var word in words)
 			{
-				var wordStartIndex = fullMessage.IndexOf(word, searchStartIndex);
+				var wordStartIndex = fullMessage.IndexOf(word, searchStartIndex, StringComparison.Ordinal);
 				if (wordStartIndex < 0)
 				{
 					continue;

--- a/CatCore/Services/Twitch/Media/TwitchEmoteDetectionHelper.cs
+++ b/CatCore/Services/Twitch/Media/TwitchEmoteDetectionHelper.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using CatCore.Models.Shared;

--- a/CatCore/Services/Twitch/Media/TwitchEmoteDetectionHelper.cs
+++ b/CatCore/Services/Twitch/Media/TwitchEmoteDetectionHelper.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Text;
 using CatCore.Models.Shared;
+using CatCore.Models.Twitch.EventSub;
 using CatCore.Models.Twitch.IRC;
 using CatCore.Models.Twitch.Media;
 using CatCore.Services.Interfaces;
@@ -150,6 +151,101 @@ namespace CatCore.Services.Twitch.Media
 			}
 
 			ExtractOtherEmotesInternal(loopStartIndex, message.Length);
+		}
+
+		/// <summary>
+		/// Extracts emote information from EventSub chat message fragments.
+		/// </summary>
+		/// <param name="message">The message text</param>
+		/// <param name="fragments">EventSub message fragments</param>
+		/// <param name="channelId">The channel ID</param>
+		/// <param name="bits">Number of bits (for cheermotes)</param>
+		/// <returns>List of extracted emotes</returns>
+		public List<IChatEmote> ExtractEmoteInfoFromFragments(string message, List<EventSubFragment> fragments, string channelId, uint bits)
+		{
+			var emotes = new List<IChatEmote>();
+
+			if (fragments == null)
+			{
+				return emotes;
+			}
+
+			var twitchConfig = _settingsService.Config.TwitchConfig;
+
+			// Extract Twitch emotes from fragments
+			if (twitchConfig.ParseTwitchEmotes)
+			{
+				foreach (var fragment in fragments)
+				{
+					if (fragment.Type == "emote" && fragment.Emote.HasValue)
+					{
+						var emoteFragment = fragment.Emote.Value;
+						var prefixedEmoteId = "TwitchEmote_" + emoteFragment.Id;
+
+						// Find the position of this emote text in the message
+						var startIndex = message.IndexOf(fragment.Text);
+						if (startIndex >= 0)
+						{
+							var endIndex = startIndex + fragment.Text.Length - 1;
+							var emoteUrl = $"https://static-cdn.jtvnw.net/emoticons/v2/{emoteFragment.Id}/static/dark/3.0";
+							emotes.Add(new TwitchEmote(prefixedEmoteId, fragment.Text, startIndex, endIndex, emoteUrl));
+						}
+					}
+				}
+			}
+
+			// Extract emojis
+			if (_settingsService.Config.GlobalConfig.HandleEmojis)
+			{
+				ExtractEmojis(emotes, message);
+			}
+
+			// Extract cheermotes and custom emotes from non-emote fragments
+			if (twitchConfig.ParseCheermotes && bits > 0 || twitchConfig.ParseBttvEmotes || twitchConfig.ParseFfzEmotes)
+			{
+				foreach (var fragment in fragments)
+				{
+					if (fragment.Type == "text")
+					{
+						ExtractOtherEmotesFromText(emotes, fragment.Text, message, channelId, twitchConfig.ParseCheermotes && bits > 0, twitchConfig.ParseBttvEmotes || twitchConfig.ParseFfzEmotes);
+					}
+				}
+			}
+
+			return emotes;
+		}
+
+		private void ExtractOtherEmotesFromText(List<IChatEmote> emotes, string fragmentText, string fullMessage, string channelId, bool parseCheermotes, bool parseCustomEmotes)
+		{
+			if (!parseCheermotes && !parseCustomEmotes)
+			{
+				return;
+			}
+
+			var words = fragmentText.Split(new[] { ' ', '\t', '\n', '\r' }, System.StringSplitOptions.RemoveEmptyEntries);
+			var searchStartIndex = 0;
+
+			foreach (var word in words)
+			{
+				var wordStartIndex = fullMessage.IndexOf(word, searchStartIndex);
+				if (wordStartIndex < 0)
+				{
+					continue;
+				}
+
+				var wordEndIndex = wordStartIndex + word.Length - 1;
+
+				if (parseCustomEmotes && _twitchMediaDataProvider.TryGetThirdPartyEmote(word, channelId, out var customEmote))
+				{
+					emotes.Add(new TwitchEmote(customEmote!.Id, customEmote.Name, wordStartIndex, wordEndIndex, customEmote.Url, customEmote.IsAnimated));
+				}
+				else if (parseCheermotes && _twitchMediaDataProvider.TryGetCheermote(word, channelId, out var emoteBits, out var cheermoteData))
+				{
+					emotes.Add(new TwitchEmote(cheermoteData!.Id, cheermoteData.Name, wordStartIndex, wordEndIndex, cheermoteData.Url, cheermoteData.IsAnimated, emoteBits, cheermoteData.Color));
+				}
+
+				searchStartIndex = wordEndIndex + 1;
+			}
 		}
 
 		/// <summary>

--- a/CatCore/Services/Twitch/TwitchAuthService.cs
+++ b/CatCore/Services/Twitch/TwitchAuthService.cs
@@ -43,11 +43,13 @@ namespace CatCore.Services.Twitch
 			"channel:manage:raids",
 			"channel:manage:redemptions",
 			"channel:moderate",
+			"channel:read:ads",
 			"channel:read:subscriptions",
 			"moderator:manage:announcements",
 			"moderator:manage:banned_users",
 			"moderator:manage:chat_messages",
 			"moderator:manage:chat_settings",
+			"moderator:read:followers",
 			"user:manage:chat_color",
 			"user:read:follows"
 		};

--- a/CatCore/Services/Twitch/TwitchAuthService.cs
+++ b/CatCore/Services/Twitch/TwitchAuthService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Threading;
@@ -33,6 +34,9 @@ namespace CatCore.Services.Twitch
 			"bits:read",
 			"chat:edit",
 			"chat:read",
+			"user:read:chat",
+			"user:bot",
+			"channel:bot",
 			"channel:manage:broadcast",
 			"channel:manage:polls",
 			"channel:manage:predictions",
@@ -46,6 +50,13 @@ namespace CatCore.Services.Twitch
 			"moderator:manage:chat_settings",
 			"user:manage:chat_color",
 			"user:read:follows"
+		};
+
+		private static readonly string[] _requiredEventSubChatScopes =
+		{
+			"user:read:chat",
+			"user:bot",
+			"channel:bot"
 		};
 
 		private readonly ILogger _logger;
@@ -145,7 +156,10 @@ namespace CatCore.Services.Twitch
 				try
 				{
 					var validateAccessToken = await ValidateAccessToken(Credentials, false).ConfigureAwait(false);
-					_logger.Information("Validated token: Is valid: {IsValid}, Is refreshable: {IsRefreshable}", validateAccessToken != null && TokenIsValid, Credentials.RefreshToken != null);
+					_logger.Information("Validated token: Is valid: {IsValid}, Is refreshable: {IsRefreshable}, Scopes: {Scopes}",
+						validateAccessToken != null && TokenIsValid,
+						Credentials.RefreshToken != null,
+						validateAccessToken?.Scopes == null ? "<none>" : string.Join(",", validateAccessToken.Value.Scopes));
 					if (validateAccessToken == null || !TokenIsValid)
 					{
 						_logger.Information("Refreshing tokens");
@@ -238,6 +252,35 @@ namespace CatCore.Services.Twitch
 			}
 
 			var validationResponse = await responseMessage.Content.ReadFromJsonAsync(TwitchAuthSerializerContext.Default.ValidationResponse).ConfigureAwait(false);
+			if (validationResponse.Scopes == null)
+			{
+				if (resetDataOnFailure)
+				{
+					UpdateCredentials(TwitchCredentials.Empty());
+					_loggedInUser = null;
+				}
+
+				Status = AuthenticationStatus.Unauthorized;
+				_logger.Warning("Twitch token validation returned no scope information");
+				return null;
+			}
+
+			var missingScopes = _requiredEventSubChatScopes.Where(requiredScope => !validationResponse.Scopes.Contains(requiredScope)).ToArray();
+			if (missingScopes.Length > 0)
+			{
+				if (resetDataOnFailure)
+				{
+					UpdateCredentials(TwitchCredentials.Empty());
+					_loggedInUser = null;
+				}
+
+				Status = AuthenticationStatus.Unauthorized;
+				_logger.Warning("Twitch token is missing required EventSub chat scopes. Missing={MissingScopes}; Current={CurrentScopes}",
+					string.Join(",", missingScopes),
+					string.Join(",", validationResponse.Scopes));
+				return null;
+			}
+
 			_loggedInUser = validationResponse;
 
 			UpdateCredentials(credentials.ValidUntil!.Value > validationResponse.ExpiresIn

--- a/CatCore/Services/Twitch/TwitchEventSubChatService.cs
+++ b/CatCore/Services/Twitch/TwitchEventSubChatService.cs
@@ -269,9 +269,10 @@ namespace CatCore.Services.Twitch
 			}
 		}
 
-		private async Task ConnectHappenedHandler(WebSocketConnection webSocketConnection)
+		private Task ConnectHappenedHandler(WebSocketConnection webSocketConnection)
 		{
 			_logger.Verbose("EventSub WebSocket connect handler triggered");
+			return Task.CompletedTask;
 		}
 
 		private Task DisconnectHappenedHandler()

--- a/CatCore/Services/Twitch/TwitchEventSubChatService.cs
+++ b/CatCore/Services/Twitch/TwitchEventSubChatService.cs
@@ -1,0 +1,644 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using CatCore.Helpers;
+using CatCore.Helpers.JSON;
+using CatCore.Models.EventArgs;
+using CatCore.Models.Shared;
+using CatCore.Models.Twitch;
+using CatCore.Models.Twitch.EventSub;
+using CatCore.Models.Twitch.IRC;
+using CatCore.Models.Twitch.OAuth;
+using CatCore.Services.Interfaces;
+using CatCore.Services.Twitch.Interfaces;
+using CatCore.Services.Twitch.Media;
+using Serilog;
+
+namespace CatCore.Services.Twitch
+{
+	internal sealed class TwitchEventSubChatService : ITwitchIrcService
+	{
+		private const string TWITCH_EVENTSUB_ENDPOINT = "wss://eventsub.wss.twitch.tv/ws";
+
+		// EventSub subscription types for chat
+		private const string SUB_TYPE_CHANNEL_CHAT_MESSAGE = "channel.chat.message";
+		private const string SUB_TYPE_CHANNEL_CHAT_NOTIFICATION = "channel.chat.notification";
+		private const string SUB_TYPE_CHANNEL_CHAT_MESSAGE_DELETE = "channel.chat.message_delete";
+		private const string SUB_TYPE_CHANNEL_CHAT_CLEAR = "channel.chat.clear";
+		private const string SUB_TYPE_CHANNEL_CHAT_SETTINGS_UPDATE = "channel.chat_settings.update";
+		private const string EVENTSUB_VERSION = "1";
+
+		private readonly ILogger _logger;
+		private readonly IKittenWebSocketProvider _kittenWebSocketProvider;
+		private readonly IKittenPlatformActiveStateManager _activeStateManager;
+		private readonly ITwitchAuthService _twitchAuthService;
+		private readonly ITwitchChannelManagementService _twitchChannelManagementService;
+		private readonly ITwitchRoomStateTrackerService _roomStateTrackerService;
+		private readonly ITwitchUserStateTrackerService _userStateTrackerService;
+		private readonly TwitchEmoteDetectionHelper _twitchEmoteDetectionHelper;
+		private readonly TwitchMediaDataProvider _twitchMediaDataProvider;
+		private readonly TwitchHelixApiService _twitchHelixApiService;
+
+		private string? _sessionId;
+		private string? _reconnectUrl;
+		private ValidationResponse? _loggedInUser;
+
+		// channelId → subscriptionIds[]
+		private readonly ConcurrentDictionary<string, List<string>> _channelSubscriptionIds;
+
+		private readonly SemaphoreSlim _connectionLockerSemaphoreSlim = new(1, 1);
+
+		public TwitchEventSubChatService(ILogger logger, IKittenWebSocketProvider kittenWebSocketProvider, IKittenPlatformActiveStateManager activeStateManager,
+			ITwitchAuthService twitchAuthService, ITwitchChannelManagementService twitchChannelManagementService, ITwitchRoomStateTrackerService roomStateTrackerService,
+			ITwitchUserStateTrackerService userStateTrackerService, TwitchEmoteDetectionHelper twitchEmoteDetectionHelper, TwitchMediaDataProvider twitchMediaDataProvider,
+			TwitchHelixApiService twitchHelixApiService)
+		{
+			_logger = logger;
+			_kittenWebSocketProvider = kittenWebSocketProvider;
+			_activeStateManager = activeStateManager;
+			_twitchAuthService = twitchAuthService;
+			_twitchChannelManagementService = twitchChannelManagementService;
+			_roomStateTrackerService = roomStateTrackerService;
+			_userStateTrackerService = userStateTrackerService;
+			_twitchEmoteDetectionHelper = twitchEmoteDetectionHelper;
+			_twitchMediaDataProvider = twitchMediaDataProvider;
+			_twitchHelixApiService = twitchHelixApiService;
+
+			_twitchAuthService.OnCredentialsChanged += TwitchAuthServiceOnOnCredentialsChanged;
+			_twitchChannelManagementService.ChannelsUpdated += TwitchChannelManagementServiceOnChannelsUpdated;
+
+			_channelSubscriptionIds = new ConcurrentDictionary<string, List<string>>();
+		}
+
+		public event Action? OnChatConnected;
+		public event Action<TwitchChannel>? OnJoinChannel;
+		public event Action<TwitchChannel>? OnLeaveChannel;
+		public event Action<TwitchChannel>? OnRoomStateChanged;
+		public event Action<TwitchMessage>? OnMessageReceived;
+		public event Action<TwitchChannel, string>? OnMessageDeleted;
+		public event Action<TwitchChannel, string?>? OnChatCleared;
+
+		public void SendMessage(TwitchChannel channel, string message)
+		{
+			if (_loggedInUser == null)
+			{
+				_logger.Warning("Cannot send message: not logged in");
+				return;
+			}
+
+			_ = Task.Run(async () =>
+			{
+				var senderUserId = _loggedInUser?.UserId ?? string.Empty;
+				if (senderUserId.Length == 0)
+				{
+					_logger.Warning("Cannot send message: user id is unavailable");
+					return;
+				}
+
+				var success = await _twitchHelixApiService.SendChatMessage(channel.Id, senderUserId, message).ConfigureAwait(false);
+				if (!success)
+				{
+					_logger.Warning("Failed to send message to channel {ChannelId}", channel.Id);
+				}
+			});
+		}
+
+		Task ITwitchIrcService.Start()
+		{
+			_logger.Verbose("Start requested by service manager");
+			return StartInternal();
+		}
+
+		Task ITwitchIrcService.Stop()
+		{
+			_logger.Verbose("Stop requested by service manager");
+			return StopInternal();
+		}
+
+		private async Task StartInternal()
+		{
+			using var _ = await Synchronization.LockAsync(_connectionLockerSemaphoreSlim);
+			if (!_twitchAuthService.HasTokens)
+			{
+				return;
+			}
+
+			_loggedInUser = await _twitchAuthService.FetchLoggedInUserInfoWithRefresh().ConfigureAwait(false);
+			if (_loggedInUser == null)
+			{
+				return;
+			}
+
+			_kittenWebSocketProvider.ConnectHappened -= ConnectHappenedHandler;
+			_kittenWebSocketProvider.ConnectHappened += ConnectHappenedHandler;
+
+			_kittenWebSocketProvider.DisconnectHappened -= DisconnectHappenedHandler;
+			_kittenWebSocketProvider.DisconnectHappened += DisconnectHappenedHandler;
+
+			_kittenWebSocketProvider.MessageReceived -= MessageReceivedHandler;
+			_kittenWebSocketProvider.MessageReceived += MessageReceivedHandler;
+
+			var connectUrl = _reconnectUrl ?? TWITCH_EVENTSUB_ENDPOINT;
+			await _kittenWebSocketProvider.Connect(connectUrl).ConfigureAwait(false);
+		}
+
+		private async Task StopInternal()
+		{
+			// Unsubscribe from all channels
+			var channelIds = _channelSubscriptionIds.Keys.ToList();
+			foreach (var channelId in channelIds)
+			{
+				await UnsubscribeFromChannelInternal(channelId).ConfigureAwait(false);
+			}
+
+			await _kittenWebSocketProvider.Disconnect().ConfigureAwait(false);
+
+			_kittenWebSocketProvider.ConnectHappened -= ConnectHappenedHandler;
+			_kittenWebSocketProvider.DisconnectHappened -= DisconnectHappenedHandler;
+			_kittenWebSocketProvider.MessageReceived -= MessageReceivedHandler;
+
+			_loggedInUser = null;
+			_sessionId = null;
+			_reconnectUrl = null;
+		}
+
+		private async void TwitchAuthServiceOnOnCredentialsChanged()
+		{
+			if (_twitchAuthService.HasTokens)
+			{
+				if (_activeStateManager.GetState(PlatformType.Twitch))
+				{
+					_logger.Verbose("(Re)start requested by credential changes");
+					await StartInternal().ConfigureAwait(false);
+				}
+			}
+			else
+			{
+				await StopInternal().ConfigureAwait(false);
+			}
+		}
+
+		private void TwitchChannelManagementServiceOnChannelsUpdated(object sender, TwitchChannelsUpdatedEventArgs e)
+		{
+			if (_activeStateManager.GetState(PlatformType.Twitch))
+			{
+				foreach (var disabledChannel in e.DisabledChannels)
+				{
+					_ = Task.Run(() => UnsubscribeFromChannelInternal(disabledChannel.Key));
+				}
+
+				foreach (var enabledChannel in e.EnabledChannels)
+				{
+					_ = Task.Run(() => SubscribeToChannelInternal(enabledChannel.Key, enabledChannel.Value));
+				}
+			}
+		}
+
+		private async Task ConnectHappenedHandler(WebSocketConnection webSocketConnection)
+		{
+			_logger.Verbose("EventSub WebSocket connect handler triggered");
+		}
+
+		private Task DisconnectHappenedHandler()
+		{
+			_reconnectUrl = null;
+
+			return Task.CompletedTask;
+		}
+
+		private Task MessageReceivedHandler(WebSocketConnection webSocketConnection, string message)
+		{
+			MessageReceivedHandlerInternal(webSocketConnection, message);
+			return Task.CompletedTask;
+		}
+
+		private void MessageReceivedHandlerInternal(WebSocketConnection webSocketConnection, string rawMessage)
+		{
+#if DEBUG
+			_logger.Verbose("EventSub message received: {Message}", rawMessage);
+#endif
+
+			try
+			{
+				// Parse the top-level message to determine type
+				using var jsonDocument = JsonDocument.Parse(rawMessage);
+				var root = jsonDocument.RootElement;
+
+				if (!root.TryGetProperty("metadata", out var metadataElement))
+				{
+					_logger.Warning("Received EventSub message without metadata");
+					return;
+				}
+
+				using var metadataDocument = JsonDocument.Parse(metadataElement.GetRawText());
+				var metadata = JsonSerializer.Deserialize(metadataDocument.RootElement, TwitchEventSubSerializerContext.Default.EventSubMetadata);
+
+				HandleEventSubMessage(metadata, rawMessage);
+			}
+			catch (Exception ex)
+			{
+				_logger.Warning(ex, "Failed to parse EventSub message");
+			}
+		}
+
+		private void HandleEventSubMessage(EventSubMetadata metadata, string rawMessage)
+		{
+			switch (metadata.MessageType)
+			{
+				case "session_welcome":
+					HandleSessionWelcome(rawMessage);
+					break;
+				case "session_keepalive":
+					// NOP
+					break;
+				case "session_reconnect":
+					HandleSessionReconnect(rawMessage);
+					break;
+				case "notification":
+					HandleNotification(metadata, rawMessage);
+					break;
+				case "revocation":
+					HandleRevocation(rawMessage);
+					break;
+				default:
+					_logger.Verbose("Received unknown EventSub message type: {MessageType}", metadata.MessageType);
+					break;
+			}
+		}
+
+		private void HandleSessionWelcome(string rawMessage)
+		{
+			try
+			{
+				using var jsonDocument = JsonDocument.Parse(rawMessage);
+				var payload = JsonSerializer.Deserialize(
+					jsonDocument.RootElement.GetProperty("payload"),
+					TwitchEventSubSerializerContext.Default.EventSubSessionPayload);
+
+				_sessionId = payload.Session.Id;
+				_reconnectUrl = null;
+
+				_logger.Information("EventSub session established. Session ID: {SessionId}", _sessionId);
+
+				OnChatConnected?.Invoke();
+
+				// Subscribe to all active channels
+				_ = Task.Run(() => SubscribeToAllChannelsInternal());
+			}
+			catch (Exception ex)
+			{
+				_logger.Warning(ex, "Failed to handle session_welcome");
+			}
+		}
+
+		private void HandleSessionReconnect(string rawMessage)
+		{
+			try
+			{
+				using var jsonDocument = JsonDocument.Parse(rawMessage);
+				var payload = JsonSerializer.Deserialize(
+					jsonDocument.RootElement.GetProperty("payload"),
+					TwitchEventSubSerializerContext.Default.EventSubSessionPayload);
+
+				_reconnectUrl = payload.Session.ReconnectUrl;
+
+				_logger.Information("EventSub session reconnect requested. New URL: {ReconnectUrl}", _reconnectUrl);
+
+				// Disconnect current connection (will trigger reconnect with new URL)
+				_ = Task.Run(() => _kittenWebSocketProvider.Disconnect("session_reconnect"));
+			}
+			catch (Exception ex)
+			{
+				_logger.Warning(ex, "Failed to handle session_reconnect");
+			}
+		}
+
+		private void HandleNotification(EventSubMetadata metadata, string rawMessage)
+		{
+			switch (metadata.SubscriptionType)
+			{
+				case SUB_TYPE_CHANNEL_CHAT_MESSAGE:
+					HandleChatMessage(rawMessage);
+					break;
+				case SUB_TYPE_CHANNEL_CHAT_NOTIFICATION:
+					HandleChatNotification(rawMessage);
+					break;
+				case SUB_TYPE_CHANNEL_CHAT_MESSAGE_DELETE:
+					HandleMessageDelete(rawMessage);
+					break;
+				case SUB_TYPE_CHANNEL_CHAT_CLEAR:
+					HandleChatClear(rawMessage);
+					break;
+				case SUB_TYPE_CHANNEL_CHAT_SETTINGS_UPDATE:
+					HandleSettingsUpdate(rawMessage);
+					break;
+				default:
+					_logger.Verbose("Received unknown subscription type: {SubscriptionType}", metadata.SubscriptionType);
+					break;
+			}
+		}
+
+		private void HandleChatMessage(string rawMessage)
+		{
+			try
+			{
+				using var jsonDocument = JsonDocument.Parse(rawMessage);
+				var payload = JsonSerializer.Deserialize(
+					jsonDocument.RootElement.GetProperty("payload"),
+					TwitchEventSubSerializerContext.Default.EventSubChatMessagePayload);
+
+				var ev = payload.Event;
+				var channel = new TwitchChannel(this, ev.BroadcasterUserId, ev.BroadcasterUserLogin);
+
+				// Build badges
+				var badgeEntries = new List<IChatBadge>();
+				foreach (var badge in ev.Badges ?? new List<EventSubBadge>())
+				{
+					var badgeIdentifier = $"{badge.SetId}/{badge.Id}";
+					if (_twitchMediaDataProvider.TryGetBadge(badgeIdentifier, ev.BroadcasterUserId, out var badgeObj))
+					{
+						badgeEntries.Add(badgeObj!);
+					}
+				}
+
+				// Build user
+				var user = new TwitchUser(
+					ev.ChatterUserId,
+					ev.ChatterUserLogin,
+					ev.ChatterUserName,
+					ev.Color,
+					ev.Badges?.Any(b => b.SetId == "moderator") ?? false,
+					ev.Badges?.Any(b => b.SetId == "broadcaster") ?? false,
+					ev.Badges?.Any(b => b.SetId == "subscriber" || b.SetId == "founder") ?? false,
+					ev.Badges?.Any(b => b.SetId == "turbo") ?? false,
+					ev.Badges?.Any(b => b.SetId == "vip") ?? false,
+					badgeEntries.AsReadOnly()
+				);
+
+				// Extract emotes
+				var emotes = _twitchEmoteDetectionHelper.ExtractEmoteInfoFromFragments(
+					ev.Message.Text,
+					ev.Message.Fragments,
+					ev.BroadcasterUserId,
+					(uint)(ev.Cheer?.Bits ?? 0)
+				);
+
+				// Build TwitchMessage
+				var twitchMessage = new TwitchMessage(
+					ev.MessageId,
+					false,
+					ev.MessageType == "ACTION",
+					ev.Message.Text.Contains($"@{_loggedInUser?.LoginName}"),
+					ev.Message.Text,
+					user,
+					channel,
+					emotes.AsReadOnly(),
+					null, // Metadata (not needed for EventSub)
+					"PRIVMSG", // IRC type equivalent
+					(uint)(ev.Cheer?.Bits ?? 0)
+				);
+
+				OnMessageReceived?.Invoke(twitchMessage);
+			}
+			catch (Exception ex)
+			{
+				_logger.Warning(ex, "Failed to handle channel.chat.message");
+			}
+		}
+
+		private void HandleChatNotification(string rawMessage)
+		{
+			try
+			{
+				using var jsonDocument = JsonDocument.Parse(rawMessage);
+				var payload = JsonSerializer.Deserialize(
+					jsonDocument.RootElement.GetProperty("payload"),
+					TwitchEventSubSerializerContext.Default.EventSubChatNotificationPayload);
+
+				var ev = payload.Event;
+				var channel = new TwitchChannel(this, ev.BroadcasterUserId, ev.BroadcasterUserLogin);
+
+				// Build user
+				var user = new TwitchUser(
+					ev.ChatterUserId,
+					ev.ChatterUserLogin,
+					ev.ChatterUserName,
+					"#ffffff",
+					false,
+					false,
+					false,
+					false,
+					false,
+					new ReadOnlyCollection<IChatBadge>(new List<IChatBadge>())
+				);
+
+				// Extract emotes
+				var emotes = _twitchEmoteDetectionHelper.ExtractEmoteInfoFromFragments(
+					ev.Message.Text,
+					ev.Message.Fragments,
+					ev.BroadcasterUserId,
+					0
+				);
+
+				var twitchMessage = new TwitchMessage(
+					Guid.NewGuid().ToString(),
+					true, // IsSystemMessage
+					false,
+					false,
+					ev.Message.Text,
+					user,
+					channel,
+					emotes.AsReadOnly(),
+					null,
+					"USERNOTICE",
+					0
+				);
+
+				OnMessageReceived?.Invoke(twitchMessage);
+			}
+			catch (Exception ex)
+			{
+				_logger.Warning(ex, "Failed to handle channel.chat.notification");
+			}
+		}
+
+		private void HandleMessageDelete(string rawMessage)
+		{
+			try
+			{
+				using var jsonDocument = JsonDocument.Parse(rawMessage);
+				var payload = JsonSerializer.Deserialize(
+					jsonDocument.RootElement.GetProperty("payload"),
+					TwitchEventSubSerializerContext.Default.EventSubChatMessageDeletePayload);
+
+				var ev = payload.Event;
+				var channel = new TwitchChannel(this, ev.BroadcasterUserId, ev.BroadcasterUserLogin);
+
+				OnMessageDeleted?.Invoke(channel, ev.MessageId);
+			}
+			catch (Exception ex)
+			{
+				_logger.Warning(ex, "Failed to handle channel.chat.message.delete");
+			}
+		}
+
+		private void HandleChatClear(string rawMessage)
+		{
+			try
+			{
+				using var jsonDocument = JsonDocument.Parse(rawMessage);
+				var payload = JsonSerializer.Deserialize(
+					jsonDocument.RootElement.GetProperty("payload"),
+					TwitchEventSubSerializerContext.Default.EventSubChatClearPayload);
+
+				var ev = payload.Event;
+				var channel = new TwitchChannel(this, ev.BroadcasterUserId, ev.BroadcasterUserLogin);
+
+				OnChatCleared?.Invoke(channel, null);
+			}
+			catch (Exception ex)
+			{
+				_logger.Warning(ex, "Failed to handle channel.chat.clear");
+			}
+		}
+
+		private void HandleSettingsUpdate(string rawMessage)
+		{
+			try
+			{
+				using var jsonDocument = JsonDocument.Parse(rawMessage);
+				var payload = JsonSerializer.Deserialize(
+					jsonDocument.RootElement.GetProperty("payload"),
+					TwitchEventSubSerializerContext.Default.EventSubChatSettingsPayload);
+
+				var ev = payload.Event;
+
+				// Build IRC-equivalent tags dictionary
+				var tags = new Dictionary<string, string>();
+				if (ev.EmoteMode)
+				{
+					tags[IrcMessageTags.EMOTE_ONLY] = "1";
+				}
+				if (ev.FollowerMode)
+				{
+					tags[IrcMessageTags.FOLLOWERS_ONLY] = ev.FollowerModeDurationMinutes.ToString();
+				}
+				if (ev.SubscriberMode)
+				{
+					tags[IrcMessageTags.SUBS_ONLY] = "1";
+				}
+				if (ev.UniqueChatMode)
+				{
+					tags[IrcMessageTags.R9_K] = "1";
+				}
+				if (ev.SlowMode)
+				{
+					tags[IrcMessageTags.SLOW] = ev.SlowModeWaitSeconds.ToString();
+				}
+
+				var roomStateDict = new ReadOnlyDictionary<string, string>(tags);
+				_roomStateTrackerService.UpdateRoomState(ev.BroadcasterUserLogin, roomStateDict);
+
+				var channel = new TwitchChannel(this, ev.BroadcasterUserId, ev.BroadcasterUserLogin);
+				OnRoomStateChanged?.Invoke(channel);
+			}
+			catch (Exception ex)
+			{
+				_logger.Warning(ex, "Failed to handle channel.chat.settings.update");
+			}
+		}
+
+		private void HandleRevocation(string rawMessage)
+		{
+			_logger.Warning("Received revocation message: {Message}", rawMessage);
+		}
+
+		private async Task SubscribeToAllChannelsInternal()
+		{
+			if (_sessionId == null)
+			{
+				return;
+			}
+
+			var channelIds = _twitchChannelManagementService.GetAllActiveChannelIds();
+			foreach (var channelId in channelIds)
+			{
+				await SubscribeToChannelInternal(channelId, _twitchChannelManagementService.GetAllActiveChannelsAsDictionary()[channelId]).ConfigureAwait(false);
+			}
+		}
+
+		private async Task SubscribeToChannelInternal(string channelId, string channelName)
+		{
+			if (_sessionId == null)
+			{
+				_logger.Verbose("Cannot subscribe: session not established");
+				return;
+			}
+
+			if (_loggedInUser == null)
+			{
+				_logger.Warning("Cannot subscribe to channel {ChannelId}: logged in user is unavailable", channelId);
+				return;
+			}
+
+			var condition = new Dictionary<string, string>
+			{
+				{ "broadcaster_user_id", channelId },
+				{ "user_id", _loggedInUser.Value.UserId }
+			};
+			var subscriptionTypes = new[] { SUB_TYPE_CHANNEL_CHAT_MESSAGE, SUB_TYPE_CHANNEL_CHAT_NOTIFICATION, SUB_TYPE_CHANNEL_CHAT_MESSAGE_DELETE, SUB_TYPE_CHANNEL_CHAT_CLEAR, SUB_TYPE_CHANNEL_CHAT_SETTINGS_UPDATE };
+
+			var subscriptionIds = new List<string>();
+			foreach (var subType in subscriptionTypes)
+			{
+				var subscriptionId = await _twitchHelixApiService.CreateEventSubSubscription(subType, EVENTSUB_VERSION, condition, _sessionId).ConfigureAwait(false);
+				if (subscriptionId != null)
+				{
+					subscriptionIds.Add(subscriptionId);
+				}
+				else
+				{
+					_logger.Warning("Failed to create EventSub subscription type {SubscriptionType} for channel {ChannelId}", subType, channelId);
+				}
+			}
+
+			if (subscriptionIds.Count > 0)
+			{
+				_channelSubscriptionIds[channelId] = subscriptionIds;
+				OnJoinChannel?.Invoke(new TwitchChannel(this, channelId, channelName));
+			}
+			else
+			{
+				_logger.Warning("Failed to create EventSub subscriptions for channel {ChannelId}. AttemptedTypes={AttemptedTypes}", channelId, string.Join(",", subscriptionTypes));
+			}
+		}
+
+		private async Task UnsubscribeFromChannelInternal(string channelId)
+		{
+			if (!_channelSubscriptionIds.TryRemove(channelId, out var subscriptionIds))
+			{
+				return;
+			}
+
+			foreach (var subscriptionId in subscriptionIds)
+			{
+				await _twitchHelixApiService.DeleteEventSubSubscription(subscriptionId).ConfigureAwait(false);
+			}
+
+			// Get the channel name for the event
+			var channelDictionary = _twitchChannelManagementService.GetAllActiveChannelsAsDictionary(includeSelfRegardlessOfState: true);
+			if (channelDictionary.TryGetValue(channelId, out var channelName))
+			{
+				_roomStateTrackerService.UpdateRoomState(channelName, null);
+				_userStateTrackerService.UpdateUserState(channelId, null);
+
+				OnLeaveChannel?.Invoke(new TwitchChannel(this, channelId, channelName));
+			}
+		}
+	}
+}

--- a/CatCore/Services/Twitch/TwitchEventSubChatService.cs
+++ b/CatCore/Services/Twitch/TwitchEventSubChatService.cs
@@ -14,14 +14,23 @@ using CatCore.Models.Twitch;
 using CatCore.Models.Twitch.EventSub;
 using CatCore.Models.Twitch.IRC;
 using CatCore.Models.Twitch.OAuth;
+using CatCore.Models.Twitch.PubSub.Responses;
+using CatCore.Models.Twitch.PubSub.Responses.ChannelPointsChannelV1;
+using CatCore.Models.Twitch.PubSub.Responses.Polls;
+using CatCore.Models.Twitch.PubSub.Responses.Predictions;
+using CatCore.Models.Twitch.PubSub.Responses.VideoPlayback;
+using CatCore.Models.Twitch.Shared;
 using CatCore.Services.Interfaces;
 using CatCore.Services.Twitch.Interfaces;
 using CatCore.Services.Twitch.Media;
 using Serilog;
+using PredictionBadge = CatCore.Models.Twitch.PubSub.Responses.Predictions.Badge;
+using PredictionUser = CatCore.Models.Twitch.PubSub.Responses.Predictions.User;
+using RewardUser = CatCore.Models.Twitch.PubSub.Responses.ChannelPointsChannelV1.User;
 
 namespace CatCore.Services.Twitch
 {
-	internal sealed class TwitchEventSubChatService : ITwitchIrcService
+	internal sealed class TwitchEventSubChatService : ITwitchIrcService, ITwitchPubSubServiceManager
 	{
 		private const string TWITCH_EVENTSUB_ENDPOINT = "wss://eventsub.wss.twitch.tv/ws";
 
@@ -31,7 +40,20 @@ namespace CatCore.Services.Twitch
 		private const string SUB_TYPE_CHANNEL_CHAT_MESSAGE_DELETE = "channel.chat.message_delete";
 		private const string SUB_TYPE_CHANNEL_CHAT_CLEAR = "channel.chat.clear";
 		private const string SUB_TYPE_CHANNEL_CHAT_SETTINGS_UPDATE = "channel.chat_settings.update";
+		private const string SUB_TYPE_STREAM_ONLINE = "stream.online";
+		private const string SUB_TYPE_STREAM_OFFLINE = "stream.offline";
+		private const string SUB_TYPE_CHANNEL_AD_BREAK_BEGIN = "channel.ad_break.begin";
+		private const string SUB_TYPE_CHANNEL_FOLLOW = "channel.follow";
+		private const string SUB_TYPE_CHANNEL_POLL_BEGIN = "channel.poll.begin";
+		private const string SUB_TYPE_CHANNEL_POLL_PROGRESS = "channel.poll.progress";
+		private const string SUB_TYPE_CHANNEL_POLL_END = "channel.poll.end";
+		private const string SUB_TYPE_CHANNEL_PREDICTION_BEGIN = "channel.prediction.begin";
+		private const string SUB_TYPE_CHANNEL_PREDICTION_PROGRESS = "channel.prediction.progress";
+		private const string SUB_TYPE_CHANNEL_PREDICTION_LOCK = "channel.prediction.lock";
+		private const string SUB_TYPE_CHANNEL_PREDICTION_END = "channel.prediction.end";
+		private const string SUB_TYPE_CHANNEL_REWARD_REDEEM = "channel.channel_points_custom_reward_redemption.add";
 		private const string EVENTSUB_VERSION = "1";
+		private const string EVENTSUB_VERSION_FOLLOW = "2";
 
 		private readonly ILogger _logger;
 		private readonly IKittenWebSocketProvider _kittenWebSocketProvider;
@@ -52,6 +74,7 @@ namespace CatCore.Services.Twitch
 		private readonly ConcurrentDictionary<string, List<string>> _channelSubscriptionIds;
 
 		private readonly SemaphoreSlim _connectionLockerSemaphoreSlim = new(1, 1);
+		private bool _loggedUnsupportedViewCount;
 
 		public TwitchEventSubChatService(ILogger logger, IKittenWebSocketProvider kittenWebSocketProvider, IKittenPlatformActiveStateManager activeStateManager,
 			ITwitchAuthService twitchAuthService, ITwitchChannelManagementService twitchChannelManagementService, ITwitchRoomStateTrackerService roomStateTrackerService,
@@ -82,6 +105,29 @@ namespace CatCore.Services.Twitch
 		public event Action<TwitchMessage>? OnMessageReceived;
 		public event Action<TwitchChannel, string>? OnMessageDeleted;
 		public event Action<TwitchChannel, string?>? OnChatCleared;
+
+		event Action<string, ViewCountUpdate> ITwitchPubSubServiceManager.OnViewCountUpdated
+		{
+			add
+			{
+				if (!_loggedUnsupportedViewCount)
+				{
+					_loggedUnsupportedViewCount = true;
+					_logger.Warning("OnViewCountUpdated is not available via EventSub. Consider polling Helix Get Streams for viewer counts.");
+				}
+			}
+			remove
+			{
+			}
+		}
+
+		public event Action<string, StreamUp>? OnStreamUp;
+		public event Action<string, StreamDown>? OnStreamDown;
+		public event Action<string, Commercial>? OnCommercial;
+		public event Action<string, Follow>? OnFollow;
+		public event Action<string, PollData>? OnPoll;
+		public event Action<string, PredictionData>? OnPrediction;
+		public event Action<string, RewardRedeemedData>? OnRewardRedeemed;
 
 		public void SendMessage(TwitchChannel channel, string message)
 		{
@@ -117,6 +163,16 @@ namespace CatCore.Services.Twitch
 		Task ITwitchIrcService.Stop()
 		{
 			_logger.Verbose("Stop requested by service manager");
+			return StopInternal();
+		}
+
+		Task ITwitchPubSubServiceManager.Start()
+		{
+			return StartInternal();
+		}
+
+		Task ITwitchPubSubServiceManager.Stop()
+		{
 			return StopInternal();
 		}
 
@@ -337,9 +393,309 @@ namespace CatCore.Services.Twitch
 				case SUB_TYPE_CHANNEL_CHAT_SETTINGS_UPDATE:
 					HandleSettingsUpdate(rawMessage);
 					break;
+				case SUB_TYPE_STREAM_ONLINE:
+					HandleStreamOnline(rawMessage);
+					break;
+				case SUB_TYPE_STREAM_OFFLINE:
+					HandleStreamOffline(rawMessage);
+					break;
+				case SUB_TYPE_CHANNEL_AD_BREAK_BEGIN:
+					HandleCommercial(rawMessage);
+					break;
+				case SUB_TYPE_CHANNEL_FOLLOW:
+					HandleFollow(rawMessage);
+					break;
+				case SUB_TYPE_CHANNEL_POLL_BEGIN:
+				case SUB_TYPE_CHANNEL_POLL_PROGRESS:
+				case SUB_TYPE_CHANNEL_POLL_END:
+					HandlePoll(rawMessage);
+					break;
+				case SUB_TYPE_CHANNEL_PREDICTION_BEGIN:
+				case SUB_TYPE_CHANNEL_PREDICTION_PROGRESS:
+				case SUB_TYPE_CHANNEL_PREDICTION_LOCK:
+				case SUB_TYPE_CHANNEL_PREDICTION_END:
+					HandlePrediction(rawMessage);
+					break;
+				case SUB_TYPE_CHANNEL_REWARD_REDEEM:
+					HandleRewardRedeem(rawMessage);
+					break;
 				default:
 					_logger.Verbose("Received unknown subscription type: {SubscriptionType}", metadata.SubscriptionType);
 					break;
+			}
+		}
+
+		private void HandleStreamOnline(string rawMessage)
+		{
+			try
+			{
+				using var jsonDocument = JsonDocument.Parse(rawMessage);
+				var ev = jsonDocument.RootElement.GetProperty("payload").GetProperty("event");
+				if (!TryGetString(ev, "broadcaster_user_id", out var channelId))
+				{
+					return;
+				}
+
+				var startedAt = TryGetDateTime(ev, "started_at") ?? DateTimeOffset.UtcNow;
+				OnStreamUp?.Invoke(channelId, new StreamUp(ToLegacyServerTimeRaw(startedAt), 0));
+			}
+			catch (Exception ex)
+			{
+				_logger.Warning(ex, "Failed to handle stream.online");
+			}
+		}
+
+		private void HandleStreamOffline(string rawMessage)
+		{
+			try
+			{
+				using var jsonDocument = JsonDocument.Parse(rawMessage);
+				var ev = jsonDocument.RootElement.GetProperty("payload").GetProperty("event");
+				if (!TryGetString(ev, "broadcaster_user_id", out var channelId))
+				{
+					return;
+				}
+
+				OnStreamDown?.Invoke(channelId, new StreamDown(ToLegacyServerTimeRaw(DateTimeOffset.UtcNow)));
+			}
+			catch (Exception ex)
+			{
+				_logger.Warning(ex, "Failed to handle stream.offline");
+			}
+		}
+
+		private void HandleCommercial(string rawMessage)
+		{
+			try
+			{
+				using var jsonDocument = JsonDocument.Parse(rawMessage);
+				var ev = jsonDocument.RootElement.GetProperty("payload").GetProperty("event");
+				if (!TryGetString(ev, "broadcaster_user_id", out var channelId))
+				{
+					return;
+				}
+
+				var startedAt = TryGetDateTime(ev, "started_at") ?? DateTimeOffset.UtcNow;
+				OnCommercial?.Invoke(channelId, new Commercial(ToLegacyServerTimeRaw(startedAt), TryGetUInt(ev, "duration_seconds")));
+			}
+			catch (Exception ex)
+			{
+				_logger.Warning(ex, "Failed to handle channel.ad_break.begin");
+			}
+		}
+
+		private void HandleFollow(string rawMessage)
+		{
+			try
+			{
+				using var jsonDocument = JsonDocument.Parse(rawMessage);
+				var ev = jsonDocument.RootElement.GetProperty("payload").GetProperty("event");
+				if (!TryGetString(ev, "broadcaster_user_id", out var channelId) ||
+				    !TryGetString(ev, "user_id", out var userId) ||
+				    !TryGetString(ev, "user_login", out var userLogin) ||
+				    !TryGetString(ev, "user_name", out var userName))
+				{
+					return;
+				}
+
+				OnFollow?.Invoke(channelId, new Follow(userId, userLogin, userName));
+			}
+			catch (Exception ex)
+			{
+				_logger.Warning(ex, "Failed to handle channel.follow");
+			}
+		}
+
+		private void HandlePoll(string rawMessage)
+		{
+			try
+			{
+				using var jsonDocument = JsonDocument.Parse(rawMessage);
+				var ev = jsonDocument.RootElement.GetProperty("payload").GetProperty("event");
+				if (!TryGetString(ev, "broadcaster_user_id", out var channelId))
+				{
+					return;
+				}
+
+				var choices = new List<PollChoice>();
+				uint totalVoters = 0;
+				if (ev.TryGetProperty("choices", out var choicesElement) && choicesElement.ValueKind == JsonValueKind.Array)
+				{
+					foreach (var choice in choicesElement.EnumerateArray())
+					{
+						var bitsVotes = TryGetUInt(choice, "bits_votes");
+						var channelPointsVotes = TryGetUInt(choice, "channel_points_votes");
+						var votes = TryGetUInt(choice, "votes");
+						totalVoters += votes;
+						choices.Add(new PollChoice(
+							TryGetString(choice, "id", out var choiceId) ? choiceId : string.Empty,
+							TryGetString(choice, "title", out var choiceTitle) ? choiceTitle : string.Empty,
+							new Votes(votes, bitsVotes, channelPointsVotes, votes),
+							new Tokens(bitsVotes, channelPointsVotes),
+							votes));
+					}
+				}
+
+				var settings = new PollSettings(
+					new PollSettingsEntry(false, null),
+					new PollSettingsEntry(false, null),
+					new PollSettingsEntry(false, null),
+					new PollSettingsEntry(TryGetBool(ev, "bits_voting_enabled"), TryGetNullableUInt(ev, "bits_per_vote")),
+					new PollSettingsEntry(TryGetBool(ev, "channel_points_voting_enabled"), TryGetNullableUInt(ev, "channel_points_per_vote")));
+
+				var pollData = new PollData(
+					TryGetString(ev, "id", out var pollId) ? pollId : string.Empty,
+					channelId,
+					channelId,
+					TryGetString(ev, "title", out var pollTitle) ? pollTitle : string.Empty,
+					TryGetString(ev, "started_at", out var startedAtRaw) ? startedAtRaw : string.Empty,
+					TryGetString(ev, "ended_at", out var endedAtRaw) ? endedAtRaw : string.Empty,
+					string.Empty,
+					TryGetUInt(ev, "duration_seconds"),
+					settings,
+					ParsePollStatus(TryGetString(ev, "status", out var statusRaw) ? statusRaw : null),
+					choices,
+					new Votes(totalVoters, 0, 0, totalVoters),
+					new Tokens(0, 0),
+					totalVoters,
+					0,
+					null,
+					null,
+					null);
+
+				OnPoll?.Invoke(channelId, pollData);
+			}
+			catch (Exception ex)
+			{
+				_logger.Warning(ex, "Failed to handle channel.poll.*");
+			}
+		}
+
+		private void HandlePrediction(string rawMessage)
+		{
+			try
+			{
+				using var jsonDocument = JsonDocument.Parse(rawMessage);
+				var ev = jsonDocument.RootElement.GetProperty("payload").GetProperty("event");
+				if (!TryGetString(ev, "broadcaster_user_id", out var channelId))
+				{
+					return;
+				}
+
+				var outcomes = new List<Outcome>();
+				if (ev.TryGetProperty("outcomes", out var outcomesElement) && outcomesElement.ValueKind == JsonValueKind.Array)
+				{
+					foreach (var outcome in outcomesElement.EnumerateArray())
+					{
+						var topPredictors = new List<TopPredictor>();
+						if (outcome.TryGetProperty("top_predictors", out var topPredictorsElement) && topPredictorsElement.ValueKind == JsonValueKind.Array)
+						{
+							foreach (var predictor in topPredictorsElement.EnumerateArray())
+							{
+								var used = TryGetUInt(predictor, "channel_points_used");
+								var won = TryGetUInt(predictor, "channel_points_won");
+								topPredictors.Add(new TopPredictor(
+									Guid.NewGuid().ToString("N"),
+									TryGetString(ev, "id", out var eventIdRaw) ? eventIdRaw : string.Empty,
+									TryGetString(outcome, "id", out var outcomeIdRaw) ? outcomeIdRaw : string.Empty,
+									channelId,
+									used,
+									DateTime.UtcNow,
+									DateTime.UtcNow,
+									TryGetString(predictor, "user_id", out var predictorId) ? predictorId : string.Empty,
+									new PredictorResult(won > 0 ? "WIN" : "UNKNOWN", won, true),
+									TryGetString(predictor, "user_name", out var predictorName) ? predictorName : string.Empty));
+							}
+						}
+
+						outcomes.Add(new Outcome(
+							TryGetString(outcome, "id", out var outcomeId) ? outcomeId : string.Empty,
+							TryGetString(outcome, "color", out var color) ? color : string.Empty,
+							TryGetString(outcome, "title", out var outcomeTitle) ? outcomeTitle : string.Empty,
+							TryGetUInt(outcome, "channel_points"),
+							TryGetUInt(outcome, "users"),
+							topPredictors,
+							new PredictionBadge(string.Empty, string.Empty)));
+					}
+				}
+
+				var createdBy = new PredictionUser("user", channelId, TryGetString(ev, "broadcaster_user_name", out var broadcasterName) ? broadcasterName : string.Empty, null);
+				var endedAt = TryGetDateTime(ev, "ended_at")?.UtcDateTime;
+				var lockedAt = TryGetDateTime(ev, "locks_at")?.UtcDateTime;
+				var predictionData = new PredictionData(
+					TryGetString(ev, "id", out var predictionId) ? predictionId : string.Empty,
+					channelId,
+					TryGetString(ev, "title", out var predictionTitle) ? predictionTitle : string.Empty,
+					(TryGetDateTime(ev, "created_at") ?? DateTimeOffset.UtcNow).UtcDateTime,
+					createdBy,
+					endedAt,
+					endedAt.HasValue ? createdBy : (PredictionUser?)null,
+					lockedAt,
+					lockedAt.HasValue ? createdBy : (PredictionUser?)null,
+					outcomes,
+					TryGetUInt(ev, "prediction_window_seconds"),
+					ParsePredictionStatus(TryGetString(ev, "status", out var statusRaw) ? statusRaw : null),
+					TryGetString(ev, "winning_outcome_id", out var winningOutcomeId) ? winningOutcomeId : null);
+
+				OnPrediction?.Invoke(channelId, predictionData);
+			}
+			catch (Exception ex)
+			{
+				_logger.Warning(ex, "Failed to handle channel.prediction.*");
+			}
+		}
+
+		private void HandleRewardRedeem(string rawMessage)
+		{
+			try
+			{
+				using var jsonDocument = JsonDocument.Parse(rawMessage);
+				var ev = jsonDocument.RootElement.GetProperty("payload").GetProperty("event");
+				if (!TryGetString(ev, "broadcaster_user_id", out var channelId) || !ev.TryGetProperty("reward", out var rewardElement))
+				{
+					return;
+				}
+
+				var user = new RewardUser(
+					TryGetString(ev, "user_id", out var userId) ? userId : string.Empty,
+					TryGetString(ev, "user_login", out var userLogin) ? userLogin : string.Empty,
+					TryGetString(ev, "user_name", out var userName) ? userName : string.Empty);
+
+				var reward = new Reward(
+					TryGetString(rewardElement, "id", out var rewardId) ? rewardId : string.Empty,
+					channelId,
+					TryGetString(rewardElement, "title", out var rewardTitle) ? rewardTitle : string.Empty,
+					TryGetString(rewardElement, "prompt", out var prompt) ? prompt : string.Empty,
+					(int)TryGetUInt(rewardElement, "cost"),
+					false,
+					false,
+					new object(),
+					new DefaultImage(string.Empty, string.Empty, string.Empty),
+					"#000000",
+					true,
+					false,
+					true,
+					new MaxPerStream(false, 0),
+					false,
+					string.Empty,
+					DateTimeOffset.UtcNow,
+					new MaxPerUserPerStream(false, 0),
+					new GlobalCooldown(false, 0),
+					null);
+
+				var data = new RewardRedeemedData(
+					TryGetString(ev, "id", out var redemptionId) ? redemptionId : string.Empty,
+					user,
+					channelId,
+					TryGetString(ev, "redeemed_at", out var redeemedAtRaw) ? redeemedAtRaw : DateTimeOffset.UtcNow.ToString("O"),
+					reward,
+					TryGetString(ev, "status", out var status) ? status : "fulfilled");
+
+				OnRewardRedeemed?.Invoke(channelId, data);
+			}
+			catch (Exception ex)
+			{
+				_logger.Warning(ex, "Failed to handle channel.channel_points_custom_reward_redemption.add");
 			}
 		}
 
@@ -591,24 +947,39 @@ namespace CatCore.Services.Twitch
 				return;
 			}
 
-			var condition = new Dictionary<string, string>
+			var loggedInUserId = _loggedInUser.Value.UserId;
+			var subscriptionRequests = new List<(string type, string version, Dictionary<string, string> condition)>
 			{
-				{ "broadcaster_user_id", channelId },
-				{ "user_id", _loggedInUser.Value.UserId }
+				(SUB_TYPE_CHANNEL_CHAT_MESSAGE, EVENTSUB_VERSION, new Dictionary<string, string> { { "broadcaster_user_id", channelId }, { "user_id", loggedInUserId } }),
+				(SUB_TYPE_CHANNEL_CHAT_NOTIFICATION, EVENTSUB_VERSION, new Dictionary<string, string> { { "broadcaster_user_id", channelId }, { "user_id", loggedInUserId } }),
+				(SUB_TYPE_CHANNEL_CHAT_MESSAGE_DELETE, EVENTSUB_VERSION, new Dictionary<string, string> { { "broadcaster_user_id", channelId }, { "user_id", loggedInUserId } }),
+				(SUB_TYPE_CHANNEL_CHAT_CLEAR, EVENTSUB_VERSION, new Dictionary<string, string> { { "broadcaster_user_id", channelId }, { "user_id", loggedInUserId } }),
+				(SUB_TYPE_CHANNEL_CHAT_SETTINGS_UPDATE, EVENTSUB_VERSION, new Dictionary<string, string> { { "broadcaster_user_id", channelId }, { "user_id", loggedInUserId } }),
+				(SUB_TYPE_STREAM_ONLINE, EVENTSUB_VERSION, new Dictionary<string, string> { { "broadcaster_user_id", channelId } }),
+				(SUB_TYPE_STREAM_OFFLINE, EVENTSUB_VERSION, new Dictionary<string, string> { { "broadcaster_user_id", channelId } }),
+				(SUB_TYPE_CHANNEL_AD_BREAK_BEGIN, EVENTSUB_VERSION, new Dictionary<string, string> { { "broadcaster_user_id", channelId } }),
+				(SUB_TYPE_CHANNEL_FOLLOW, EVENTSUB_VERSION_FOLLOW, new Dictionary<string, string> { { "broadcaster_user_id", channelId }, { "moderator_user_id", loggedInUserId } }),
+				(SUB_TYPE_CHANNEL_POLL_BEGIN, EVENTSUB_VERSION, new Dictionary<string, string> { { "broadcaster_user_id", channelId } }),
+				(SUB_TYPE_CHANNEL_POLL_PROGRESS, EVENTSUB_VERSION, new Dictionary<string, string> { { "broadcaster_user_id", channelId } }),
+				(SUB_TYPE_CHANNEL_POLL_END, EVENTSUB_VERSION, new Dictionary<string, string> { { "broadcaster_user_id", channelId } }),
+				(SUB_TYPE_CHANNEL_PREDICTION_BEGIN, EVENTSUB_VERSION, new Dictionary<string, string> { { "broadcaster_user_id", channelId } }),
+				(SUB_TYPE_CHANNEL_PREDICTION_PROGRESS, EVENTSUB_VERSION, new Dictionary<string, string> { { "broadcaster_user_id", channelId } }),
+				(SUB_TYPE_CHANNEL_PREDICTION_LOCK, EVENTSUB_VERSION, new Dictionary<string, string> { { "broadcaster_user_id", channelId } }),
+				(SUB_TYPE_CHANNEL_PREDICTION_END, EVENTSUB_VERSION, new Dictionary<string, string> { { "broadcaster_user_id", channelId } }),
+				(SUB_TYPE_CHANNEL_REWARD_REDEEM, EVENTSUB_VERSION, new Dictionary<string, string> { { "broadcaster_user_id", channelId } })
 			};
-			var subscriptionTypes = new[] { SUB_TYPE_CHANNEL_CHAT_MESSAGE, SUB_TYPE_CHANNEL_CHAT_NOTIFICATION, SUB_TYPE_CHANNEL_CHAT_MESSAGE_DELETE, SUB_TYPE_CHANNEL_CHAT_CLEAR, SUB_TYPE_CHANNEL_CHAT_SETTINGS_UPDATE };
 
 			var subscriptionIds = new List<string>();
-			foreach (var subType in subscriptionTypes)
+			foreach (var request in subscriptionRequests)
 			{
-				var subscriptionId = await _twitchHelixApiService.CreateEventSubSubscription(subType, EVENTSUB_VERSION, condition, _sessionId).ConfigureAwait(false);
+				var subscriptionId = await _twitchHelixApiService.CreateEventSubSubscription(request.type, request.version, request.condition, _sessionId).ConfigureAwait(false);
 				if (subscriptionId != null)
 				{
 					subscriptionIds.Add(subscriptionId);
 				}
 				else
 				{
-					_logger.Warning("Failed to create EventSub subscription type {SubscriptionType} for channel {ChannelId}", subType, channelId);
+					_logger.Warning("Failed to create EventSub subscription type {SubscriptionType} for channel {ChannelId}", request.type, channelId);
 				}
 			}
 
@@ -628,8 +999,98 @@ namespace CatCore.Services.Twitch
 			}
 			else
 			{
-				_logger.Warning("Failed to create EventSub subscriptions for channel {ChannelId}. AttemptedTypes={AttemptedTypes}", channelId, string.Join(",", subscriptionTypes));
+				_logger.Warning("Failed to create EventSub subscriptions for channel {ChannelId}. AttemptedTypes={AttemptedTypes}", channelId, string.Join(",", subscriptionRequests.Select(x => x.type)));
 			}
+		}
+
+		private static string ToLegacyServerTimeRaw(DateTimeOffset value)
+		{
+			var unixMicros = value.ToUnixTimeMilliseconds() * 1000L;
+			return $"{unixMicros / 1000000}.{unixMicros % 1000000:D6}";
+		}
+
+		private static bool TryGetString(JsonElement element, string propertyName, out string value)
+		{
+			if (element.TryGetProperty(propertyName, out var property) && property.ValueKind == JsonValueKind.String)
+			{
+				value = property.GetString()!;
+				return true;
+			}
+
+			value = string.Empty;
+			return false;
+		}
+
+		private static bool TryGetBool(JsonElement element, string propertyName)
+		{
+			return element.TryGetProperty(propertyName, out var property) && property.ValueKind == JsonValueKind.True;
+		}
+
+		private static uint TryGetUInt(JsonElement element, string propertyName)
+		{
+			if (!element.TryGetProperty(propertyName, out var property))
+			{
+				return 0;
+			}
+
+			if (property.ValueKind == JsonValueKind.Number && property.TryGetUInt32(out var number))
+			{
+				return number;
+			}
+
+			return 0;
+		}
+
+		private static uint? TryGetNullableUInt(JsonElement element, string propertyName)
+		{
+			if (!element.TryGetProperty(propertyName, out var property) || property.ValueKind == JsonValueKind.Null)
+			{
+				return null;
+			}
+
+			if (property.ValueKind == JsonValueKind.Number && property.TryGetUInt32(out var number))
+			{
+				return number;
+			}
+
+			return null;
+		}
+
+		private static DateTimeOffset? TryGetDateTime(JsonElement element, string propertyName)
+		{
+			if (!element.TryGetProperty(propertyName, out var property) || property.ValueKind != JsonValueKind.String)
+			{
+				return null;
+			}
+
+			var raw = property.GetString();
+			return DateTimeOffset.TryParse(raw, out var parsed) ? parsed : null;
+		}
+
+		private static PollStatus ParsePollStatus(string? status)
+		{
+			return status?.ToLowerInvariant() switch
+			{
+				"active" => PollStatus.Active,
+				"completed" => PollStatus.Completed,
+				"terminated" => PollStatus.Terminated,
+				"archived" => PollStatus.Archived,
+				"moderated" => PollStatus.Moderated,
+				_ => PollStatus.Invalid
+			};
+		}
+
+		private static PredictionStatus ParsePredictionStatus(string? status)
+		{
+			return status?.ToLowerInvariant() switch
+			{
+				"active" => PredictionStatus.Active,
+				"resolved" => PredictionStatus.Resolved,
+				"canceled" => PredictionStatus.Cancelled,
+				"cancelled" => PredictionStatus.Cancelled,
+				"locked" => PredictionStatus.Locked,
+				_ => PredictionStatus.Active
+			};
 		}
 
 		private async Task UnsubscribeFromChannelInternal(string channelId)

--- a/CatCore/Services/Twitch/TwitchEventSubChatService.cs
+++ b/CatCore/Services/Twitch/TwitchEventSubChatService.cs
@@ -276,8 +276,6 @@ namespace CatCore.Services.Twitch
 
 		private Task DisconnectHappenedHandler()
 		{
-			_reconnectUrl = null;
-
 			return Task.CompletedTask;
 		}
 
@@ -305,8 +303,7 @@ namespace CatCore.Services.Twitch
 					return;
 				}
 
-				using var metadataDocument = JsonDocument.Parse(metadataElement.GetRawText());
-				var metadata = JsonSerializer.Deserialize(metadataDocument.RootElement, TwitchEventSubSerializerContext.Default.EventSubMetadata);
+				var metadata = JsonSerializer.Deserialize(metadataElement, TwitchEventSubSerializerContext.Default.EventSubMetadata);
 
 				HandleEventSubMessage(metadata, rawMessage);
 			}
@@ -380,8 +377,29 @@ namespace CatCore.Services.Twitch
 
 				_logger.Information("EventSub session reconnect requested. New URL: {ReconnectUrl}", _reconnectUrl);
 
-				// Disconnect current connection (will trigger reconnect with new URL)
-				_ = Task.Run(() => _kittenWebSocketProvider.Disconnect("session_reconnect"));
+				// Establish a new connection using the reconnect URL, then drop the old one per EventSub reconnect semantics.
+				_ = Task.Run(async () =>
+				{
+					try
+					{
+						// Connect to the new URL (_reconnectUrl is already set, StartInternal will use it)
+						await StartInternal().ConfigureAwait(false);
+					}
+					catch (Exception ex)
+					{
+						_logger.Warning(ex, "Failed to start new EventSub session during session_reconnect");
+					}
+
+					try
+					{
+						// Disconnect old connection after attempting to bring up the new one
+						await _kittenWebSocketProvider.Disconnect("session_reconnect").ConfigureAwait(false);
+					}
+					catch (Exception ex)
+					{
+						_logger.Warning(ex, "Failed to disconnect old EventSub session during session_reconnect");
+					}
+				});
 			}
 			catch (Exception ex)
 			{
@@ -985,6 +1003,7 @@ namespace CatCore.Services.Twitch
 			};
 
 			var subscriptionIds = new List<string>();
+			var allSucceeded = true;
 			foreach (var request in subscriptionRequests)
 			{
 				var subscriptionId = await _twitchHelixApiService.CreateEventSubSubscription(request.type, request.version, request.condition, _sessionId).ConfigureAwait(false);
@@ -995,12 +1014,14 @@ namespace CatCore.Services.Twitch
 				else
 				{
 					_logger.Warning("Failed to create EventSub subscription type {SubscriptionType} for channel {ChannelId}", request.type, channelId);
+					allSucceeded = false;
 				}
 			}
 
-			if (subscriptionIds.Count > 0)
+			if (subscriptionIds.Count > 0 && allSucceeded)
 			{
-				// Delete any existing subscriptions for this channel before replacing to avoid leaks.
+				// Only delete existing subscriptions and replace when ALL new ones were created successfully,
+				// to avoid silently reducing coverage for the channel on partial failure.
 				if (_channelSubscriptionIds.TryRemove(channelId, out var existingSubscriptionIds))
 				{
 					foreach (var existingId in existingSubscriptionIds)
@@ -1012,9 +1033,22 @@ namespace CatCore.Services.Twitch
 				_channelSubscriptionIds[channelId] = subscriptionIds;
 				OnJoinChannel?.Invoke(new TwitchChannel(this, channelId, channelName));
 			}
-			else
+			else if (subscriptionIds.Count == 0)
 			{
 				_logger.Warning("Failed to create EventSub subscriptions for channel {ChannelId}. AttemptedTypes={AttemptedTypes}", channelId, string.Join(",", subscriptionRequests.Select(x => x.type)));
+			}
+			else
+			{
+				// Partial failure: clean up the newly created subscriptions to avoid leaks.
+				_logger.Warning("Partial failure creating EventSub subscriptions for channel {ChannelId}. Rolling back {Count} created subscriptions.", channelId, subscriptionIds.Count);
+				foreach (var subscriptionId in subscriptionIds)
+				{
+					var deleted = await _twitchHelixApiService.DeleteEventSubSubscription(subscriptionId).ConfigureAwait(false);
+					if (!deleted)
+					{
+						_logger.Warning("Failed to delete EventSub subscription {SubscriptionId} during rollback for channel {ChannelId}", subscriptionId, channelId);
+					}
+				}
 			}
 		}
 

--- a/CatCore/Services/Twitch/TwitchEventSubChatService.cs
+++ b/CatCore/Services/Twitch/TwitchEventSubChatService.cs
@@ -12,6 +12,7 @@ using CatCore.Models.EventArgs;
 using CatCore.Models.Shared;
 using CatCore.Models.Twitch;
 using CatCore.Models.Twitch.EventSub;
+using CatCore.Models.Twitch.Helix.Responses;
 using CatCore.Models.Twitch.IRC;
 using CatCore.Models.Twitch.OAuth;
 using CatCore.Models.Twitch.PubSub.Responses;
@@ -75,6 +76,7 @@ namespace CatCore.Services.Twitch
 		// channelId → subscriptionIds[]
 		private readonly ConcurrentDictionary<string, List<string>> _channelSubscriptionIds;
 		private readonly ConcurrentDictionary<Action<string, ViewCountUpdate>, bool> _viewCountCallbackRegistrations = new();
+		private readonly ConcurrentDictionary<string, string> _profileImageUrlCache = new(StringComparer.OrdinalIgnoreCase);
 
 		private readonly SemaphoreSlim _connectionLockerSemaphoreSlim = new(1, 1);
 		private readonly object _viewCountPollingStateLock = new();
@@ -744,6 +746,7 @@ namespace CatCore.Services.Twitch
 
 				var ev = payload.Event;
 				var channel = new TwitchChannel(this, ev.BroadcasterUserId, ev.BroadcasterUserLogin);
+				var chatterColor = NormalizeHexColorOrDefault(ev.Color, "#FFFFFF");
 
 				// Build badges
 				var badgeEntries = new List<IChatBadge>();
@@ -761,7 +764,7 @@ namespace CatCore.Services.Twitch
 					ev.ChatterUserId,
 					ev.ChatterUserLogin,
 					ev.ChatterUserName,
-					ev.Color,
+					chatterColor,
 					ev.Badges?.Any(b => b.SetId == "moderator") ?? false,
 					ev.Badges?.Any(b => b.SetId == "broadcaster") ?? false,
 					ev.Badges?.Any(b => b.SetId == "subscriber" || b.SetId == "founder") ?? false,
@@ -820,6 +823,13 @@ namespace CatCore.Services.Twitch
 
 				var ev = payload.Event;
 				var channel = new TwitchChannel(this, ev.BroadcasterUserId, ev.BroadcasterUserLogin);
+				var userMessageText = ev.Message.Text ?? string.Empty;
+				var notificationText = ResolveNotificationText(ev);
+				var notificationMetadata = BuildLegacyUserNoticeMetadata(ev, notificationText);
+				if (string.IsNullOrWhiteSpace(notificationText))
+				{
+					_logger.Warning("EventSub notification text resolved empty for notice type {NoticeType}", ev.NoticeType);
+				}
 
 				// Build user
 				var user = new TwitchUser(
@@ -837,7 +847,7 @@ namespace CatCore.Services.Twitch
 
 				// Extract emotes
 				var emotes = _twitchEmoteDetectionHelper.ExtractEmoteInfoFromFragments(
-					ev.Message.Text,
+					userMessageText,
 					ev.Message.Fragments,
 					ev.BroadcasterUserId,
 					0
@@ -848,11 +858,11 @@ namespace CatCore.Services.Twitch
 					true, // IsSystemMessage
 					false,
 					false,
-					ev.Message.Text,
+					userMessageText,
 					user,
 					channel,
 					emotes.AsReadOnly(),
-					null,
+					notificationMetadata,
 					"USERNOTICE",
 					0
 				);
@@ -863,6 +873,234 @@ namespace CatCore.Services.Twitch
 			{
 				_logger.Warning(ex, "Failed to handle channel.chat.notification");
 			}
+		}
+
+		private ReadOnlyDictionary<string, string> BuildLegacyUserNoticeMetadata(EventSubChatNotificationEvent ev, string notificationText)
+		{
+			var metadataLogin = ev.ChatterUserLogin;
+			var metadataDisplayName = ev.ChatterUserName;
+			var profileLookupUserId = ev.ChatterUserId;
+
+			if (ev.Raid.HasValue)
+			{
+				if (!string.IsNullOrWhiteSpace(ev.Raid.Value.UserLogin))
+				{
+					metadataLogin = ev.Raid.Value.UserLogin;
+				}
+
+				if (!string.IsNullOrWhiteSpace(ev.Raid.Value.UserName))
+				{
+					metadataDisplayName = ev.Raid.Value.UserName;
+				}
+
+				if (!string.IsNullOrWhiteSpace(ev.Raid.Value.UserId))
+				{
+					profileLookupUserId = ev.Raid.Value.UserId;
+				}
+			}
+
+			var metadata = new Dictionary<string, string>(StringComparer.Ordinal)
+			{
+				[IrcMessageTags.MSG_ID] = string.IsNullOrWhiteSpace(ev.NoticeType) ? "usernotice" : ev.NoticeType,
+				[IrcMessageTags.SYSTEM_MSG] = EscapeLegacyIrcSystemMessage(notificationText)
+			};
+
+			if (!string.IsNullOrWhiteSpace(metadataLogin))
+			{
+				metadata[IrcMessageTags.MSG_PARAM_LOGIN] = metadataLogin;
+			}
+
+			if (!string.IsNullOrWhiteSpace(metadataDisplayName))
+			{
+				metadata[IrcMessageTags.MSG_PARAM_DISPLAY_NAME] = metadataDisplayName;
+			}
+
+			var profileImageUrl = TryResolveProfileImageUrl(metadataLogin, profileLookupUserId);
+			if (profileImageUrl is { Length: > 0 })
+			{
+				metadata[IrcMessageTags.MSG_PARAM_PROFILE_IMAGE_URL] = profileImageUrl;
+			}
+
+			if (ev.Raid.HasValue)
+			{
+				metadata[IrcMessageTags.MSG_PARAM_VIEWER_COUNT] = ev.Raid.Value.ViewerCount.ToString();
+			}
+
+			if (ev.Sub.HasValue)
+			{
+				metadata[IrcMessageTags.MSG_PARAM_SUB_PLAN] = ev.Sub.Value.SubTier;
+			}
+
+			if (ev.Resub.HasValue)
+			{
+				metadata[IrcMessageTags.MSG_PARAM_SUB_PLAN] = ev.Resub.Value.SubTier;
+				metadata[IrcMessageTags.MSG_PARAM_CUMULATIVE_MONTHS] = ev.Resub.Value.CumulativeMonths.ToString();
+				metadata[IrcMessageTags.MSG_PARAM_MONTHS] = ev.Resub.Value.DurationMonths.ToString();
+			}
+
+			if (ev.GiftSub.HasValue)
+			{
+				if (!string.IsNullOrWhiteSpace(ev.GiftSub.Value.RecipientUserName))
+				{
+					metadata[IrcMessageTags.MSG_PARAM_RECIPIENT_USER_NAME] = ev.GiftSub.Value.RecipientUserName;
+					metadata[IrcMessageTags.MSG_PARAM_RECIPIENT_DISPLAY_NAME] = ev.GiftSub.Value.RecipientUserName;
+				}
+
+				metadata[IrcMessageTags.MSG_PARAM_SUB_PLAN] = ev.GiftSub.Value.SubTier;
+			}
+
+			return new ReadOnlyDictionary<string, string>(metadata);
+		}
+
+		private string? TryResolveProfileImageUrl(string? loginName, string? userId)
+		{
+			if (!string.IsNullOrWhiteSpace(userId) && _profileImageUrlCache.TryGetValue($"id:{userId}", out var cachedById))
+			{
+				return cachedById;
+			}
+
+			if (!string.IsNullOrWhiteSpace(loginName) && _profileImageUrlCache.TryGetValue($"login:{loginName}", out var cachedByLogin))
+			{
+				return cachedByLogin;
+			}
+
+			try
+			{
+				ResponseBase<UserData>? userInfo = null;
+
+				if (!string.IsNullOrWhiteSpace(userId))
+				{
+					userInfo = _twitchHelixApiService.FetchUserInfo(userIds: new[] { userId! }).ConfigureAwait(false).GetAwaiter().GetResult();
+				}
+
+				if ((userInfo?.Data?.Count ?? 0) == 0 && !string.IsNullOrWhiteSpace(loginName))
+				{
+					userInfo = _twitchHelixApiService.FetchUserInfo(loginNames: new[] { loginName! }).ConfigureAwait(false).GetAwaiter().GetResult();
+				}
+
+				var user = userInfo?.Data?.FirstOrDefault();
+				if (!user.HasValue || string.IsNullOrWhiteSpace(user.Value.ProfileImageUrl))
+				{
+					return null;
+				}
+
+				var userValue = user.Value;
+				var profileImageUrl = userValue.ProfileImageUrl;
+				if (!string.IsNullOrWhiteSpace(userValue.UserId))
+				{
+					_profileImageUrlCache[$"id:{userValue.UserId}"] = profileImageUrl;
+				}
+
+				if (!string.IsNullOrWhiteSpace(userValue.LoginName))
+				{
+					_profileImageUrlCache[$"login:{userValue.LoginName}"] = profileImageUrl;
+				}
+
+				return profileImageUrl;
+			}
+			catch (Exception ex)
+			{
+				_logger.Verbose(ex, "Failed to resolve profile image URL for login={LoginName}, userId={UserId}", loginName, userId);
+				return null;
+			}
+		}
+
+		private static string EscapeLegacyIrcSystemMessage(string value)
+		{
+			if (string.IsNullOrEmpty(value))
+			{
+				return string.Empty;
+			}
+
+			return value.Replace(" ", "\\s");
+		}
+
+		private static string ResolveNotificationText(EventSubChatNotificationEvent ev)
+		{
+			if (!string.IsNullOrWhiteSpace(ev.Message.Text))
+			{
+				return ev.Message.Text;
+			}
+
+			if (!string.IsNullOrWhiteSpace(ev.SystemMessage))
+			{
+				return ev.SystemMessage ?? string.Empty;
+			}
+
+			return ev.NoticeType switch
+			{
+				"raid" => BuildRaidNotificationText(ev),
+				"sub" => $"{GetPreferredDisplayName(ev)} subscribed.",
+				"resub" => BuildResubNotificationText(ev),
+				"gift_sub" => BuildGiftSubNotificationText(ev),
+				"pay_it_forward" => $"{GetPreferredDisplayName(ev)} paid a gift forward.",
+				"bits_badge_tier" => BuildBitsBadgeTierNotificationText(ev),
+				"announcement" => GetPreferredDisplayName(ev),
+				"unraid" => $"{GetPreferredDisplayName(ev)} canceled the raid.",
+				_ => string.Empty
+			};
+		}
+
+		private static string BuildRaidNotificationText(EventSubChatNotificationEvent ev)
+		{
+			var raiderName = ev.Raid?.UserName;
+			if (string.IsNullOrWhiteSpace(raiderName))
+			{
+				raiderName = GetPreferredDisplayName(ev);
+			}
+
+			var viewerCount = ev.Raid?.ViewerCount ?? 0;
+			var viewerLabel = viewerCount == 1 ? "viewer" : "viewers";
+			return viewerCount > 0
+				? $"{raiderName} is raiding with a party of {viewerCount} {viewerLabel}."
+				: $"{raiderName} is raiding.";
+		}
+
+		private static string BuildResubNotificationText(EventSubChatNotificationEvent ev)
+		{
+			var userName = GetPreferredDisplayName(ev);
+			var cumulativeMonths = ev.Resub?.CumulativeMonths ?? 0;
+			return cumulativeMonths > 0
+				? $"{userName} subscribed for {cumulativeMonths} months."
+				: $"{userName} resubscribed.";
+		}
+
+		private static string BuildGiftSubNotificationText(EventSubChatNotificationEvent ev)
+		{
+			var gifterName = GetPreferredDisplayName(ev);
+			var recipientName = ev.GiftSub?.RecipientUserName;
+			return !string.IsNullOrWhiteSpace(recipientName)
+				? $"{gifterName} gifted a sub to {recipientName}."
+				: $"{gifterName} gifted a subscription.";
+		}
+
+		private static string BuildBitsBadgeTierNotificationText(EventSubChatNotificationEvent ev)
+		{
+			var userName = GetPreferredDisplayName(ev);
+			var tier = ev.BitsBadgeTier?.Tier ?? 0;
+			return tier > 0
+				? $"{userName} reached Bits badge tier {tier}."
+				: $"{userName} reached a new Bits badge tier.";
+		}
+
+		private static string GetPreferredDisplayName(EventSubChatNotificationEvent ev)
+		{
+			if (!string.IsNullOrWhiteSpace(ev.ChatterUserName))
+			{
+				return ev.ChatterUserName;
+			}
+
+			if (!string.IsNullOrWhiteSpace(ev.ChatterUserLogin))
+			{
+				return ev.ChatterUserLogin;
+			}
+
+			if (!string.IsNullOrWhiteSpace(ev.Raid?.UserName))
+			{
+				return ev.Raid?.UserName ?? string.Empty;
+			}
+
+			return string.Empty;
 		}
 
 		private void HandleMessageDelete(string rawMessage)
@@ -1004,7 +1242,7 @@ namespace CatCore.Services.Twitch
 			};
 
 			var subscriptionIds = new List<string>();
-			var allSucceeded = true;
+			var failedTypes = new List<string>();
 			foreach (var request in subscriptionRequests)
 			{
 				var subscriptionId = await _twitchHelixApiService.CreateEventSubSubscription(request.type, request.version, request.condition, _sessionId).ConfigureAwait(false);
@@ -1015,14 +1253,14 @@ namespace CatCore.Services.Twitch
 				else
 				{
 					_logger.Warning("Failed to create EventSub subscription type {SubscriptionType} for channel {ChannelId}", request.type, channelId);
-					allSucceeded = false;
+					failedTypes.Add(request.type);
 				}
 			}
 
-			if (subscriptionIds.Count > 0 && allSucceeded)
+			if (subscriptionIds.Count > 0)
 			{
-				// Only delete existing subscriptions and replace when ALL new ones were created successfully,
-				// to avoid silently reducing coverage for the channel on partial failure.
+				// Replace existing subscriptions with the successfully created set.
+				// Some EventSub types may fail due to missing optional scopes, but chat should remain functional.
 				if (_channelSubscriptionIds.TryRemove(channelId, out var existingSubscriptionIds))
 				{
 					foreach (var existingId in existingSubscriptionIds)
@@ -1032,24 +1270,16 @@ namespace CatCore.Services.Twitch
 				}
 
 				_channelSubscriptionIds[channelId] = subscriptionIds;
+				if (failedTypes.Count > 0)
+				{
+					_logger.Warning("EventSub subscriptions partially created for channel {ChannelId}. Created={CreatedCount}, FailedTypes={FailedTypes}",
+						channelId, subscriptionIds.Count, string.Join(",", failedTypes));
+				}
 				OnJoinChannel?.Invoke(new TwitchChannel(this, channelId, channelName));
 			}
 			else if (subscriptionIds.Count == 0)
 			{
 				_logger.Warning("Failed to create EventSub subscriptions for channel {ChannelId}. AttemptedTypes={AttemptedTypes}", channelId, string.Join(",", subscriptionRequests.Select(x => x.type)));
-			}
-			else
-			{
-				// Partial failure: clean up the newly created subscriptions to avoid leaks.
-				_logger.Warning("Partial failure creating EventSub subscriptions for channel {ChannelId}. Rolling back {Count} created subscriptions.", channelId, subscriptionIds.Count);
-				foreach (var subscriptionId in subscriptionIds)
-				{
-					var deleted = await _twitchHelixApiService.DeleteEventSubSubscription(subscriptionId).ConfigureAwait(false);
-					if (!deleted)
-					{
-						_logger.Warning("Failed to delete EventSub subscription {SubscriptionId} during rollback for channel {ChannelId}", subscriptionId, channelId);
-					}
-				}
 			}
 		}
 
@@ -1057,6 +1287,27 @@ namespace CatCore.Services.Twitch
 		{
 			var unixMicros = value.ToUnixTimeMilliseconds() * 1000L;
 			return $"{unixMicros / 1000000}.{unixMicros % 1000000:D6}";
+		}
+
+		private static string NormalizeHexColorOrDefault(string? rawColor, string fallback)
+		{
+			if (string.IsNullOrWhiteSpace(rawColor))
+			{
+				return fallback;
+			}
+
+			var color = rawColor!.Trim();
+			if (color.Length == 7 && color[0] == '#')
+			{
+				return color;
+			}
+
+			if (color.Length == 6)
+			{
+				return "#" + color;
+			}
+
+			return fallback;
 		}
 
 		private static bool TryGetString(JsonElement element, string propertyName, out string value)

--- a/CatCore/Services/Twitch/TwitchEventSubChatService.cs
+++ b/CatCore/Services/Twitch/TwitchEventSubChatService.cs
@@ -54,6 +54,8 @@ namespace CatCore.Services.Twitch
 		private const string SUB_TYPE_CHANNEL_REWARD_REDEEM = "channel.channel_points_custom_reward_redemption.add";
 		private const string EVENTSUB_VERSION = "1";
 		private const string EVENTSUB_VERSION_FOLLOW = "2";
+		private static readonly TimeSpan VIEW_COUNT_POLL_INTERVAL = TimeSpan.FromSeconds(30);
+		private const int HELIX_USER_IDS_PER_REQUEST_LIMIT = 100;
 
 		private readonly ILogger _logger;
 		private readonly IKittenWebSocketProvider _kittenWebSocketProvider;
@@ -72,9 +74,12 @@ namespace CatCore.Services.Twitch
 
 		// channelId → subscriptionIds[]
 		private readonly ConcurrentDictionary<string, List<string>> _channelSubscriptionIds;
+		private readonly ConcurrentDictionary<Action<string, ViewCountUpdate>, bool> _viewCountCallbackRegistrations = new();
 
 		private readonly SemaphoreSlim _connectionLockerSemaphoreSlim = new(1, 1);
-		private bool _loggedUnsupportedViewCount;
+		private readonly object _viewCountPollingStateLock = new();
+		private CancellationTokenSource? _viewCountPollingCancellationTokenSource;
+		private Task? _viewCountPollingTask;
 
 		public TwitchEventSubChatService(ILogger logger, IKittenWebSocketProvider kittenWebSocketProvider, IKittenPlatformActiveStateManager activeStateManager,
 			ITwitchAuthService twitchAuthService, ITwitchChannelManagementService twitchChannelManagementService, ITwitchRoomStateTrackerService roomStateTrackerService,
@@ -110,14 +115,21 @@ namespace CatCore.Services.Twitch
 		{
 			add
 			{
-				if (!_loggedUnsupportedViewCount)
+				if (_viewCountCallbackRegistrations.TryAdd(value, false))
 				{
-					_loggedUnsupportedViewCount = true;
-					_logger.Warning("OnViewCountUpdated is not available via EventSub. Consider polling Helix Get Streams for viewer counts.");
+					TryStartViewCountPollingIfNeeded();
+				}
+				else
+				{
+					_logger.Warning("Callback was already registered for EventHandler {Name}", nameof(ITwitchPubSubServiceManager.OnViewCountUpdated));
 				}
 			}
 			remove
 			{
+				if (_viewCountCallbackRegistrations.TryRemove(value, out _) && _viewCountCallbackRegistrations.IsEmpty)
+				{
+					_ = StopViewCountPollingIfRunning();
+				}
 			}
 		}
 
@@ -205,6 +217,8 @@ namespace CatCore.Services.Twitch
 
 		private async Task StopInternal()
 		{
+			await StopViewCountPollingIfRunning().ConfigureAwait(false);
+
 			// Unsubscribe from all channels
 			var channelIds = _channelSubscriptionIds.Keys.ToList();
 			foreach (var channelId in channelIds)
@@ -342,6 +356,7 @@ namespace CatCore.Services.Twitch
 				_logger.Information("EventSub session established. Session ID: {SessionId}", _sessionId);
 
 				OnChatConnected?.Invoke();
+				TryStartViewCountPollingIfNeeded();
 
 				// Subscribe to all active channels
 				_ = Task.Run(() => SubscribeToAllChannelsInternal());
@@ -1091,6 +1106,121 @@ namespace CatCore.Services.Twitch
 				"locked" => PredictionStatus.Locked,
 				_ => PredictionStatus.Active
 			};
+		}
+
+		private void TryStartViewCountPollingIfNeeded()
+		{
+			lock (_viewCountPollingStateLock)
+			{
+				if (_viewCountPollingCancellationTokenSource != null || _viewCountCallbackRegistrations.IsEmpty)
+				{
+					return;
+				}
+
+				if (_loggedInUser == null || !_activeStateManager.GetState(PlatformType.Twitch))
+				{
+					return;
+				}
+
+				_viewCountPollingCancellationTokenSource = new CancellationTokenSource();
+				_viewCountPollingTask = Task.Run(() => RunViewCountPollingLoop(_viewCountPollingCancellationTokenSource.Token));
+			}
+		}
+
+		private async Task StopViewCountPollingIfRunning()
+		{
+			CancellationTokenSource? cancellationTokenSource;
+			Task? pollingTask;
+
+			lock (_viewCountPollingStateLock)
+			{
+				cancellationTokenSource = _viewCountPollingCancellationTokenSource;
+				pollingTask = _viewCountPollingTask;
+				_viewCountPollingCancellationTokenSource = null;
+				_viewCountPollingTask = null;
+			}
+
+			if (cancellationTokenSource == null)
+			{
+				return;
+			}
+
+			cancellationTokenSource.Cancel();
+			try
+			{
+				if (pollingTask != null)
+				{
+					await pollingTask.ConfigureAwait(false);
+				}
+			}
+			catch (OperationCanceledException)
+			{
+				// Expected while stopping
+			}
+			finally
+			{
+				cancellationTokenSource.Dispose();
+			}
+		}
+
+		private async Task RunViewCountPollingLoop(CancellationToken cancellationToken)
+		{
+			while (!cancellationToken.IsCancellationRequested)
+			{
+				try
+				{
+					await PollViewCountsOnce(cancellationToken).ConfigureAwait(false);
+					await Task.Delay(VIEW_COUNT_POLL_INTERVAL, cancellationToken).ConfigureAwait(false);
+				}
+				catch (OperationCanceledException)
+				{
+					break;
+				}
+				catch (Exception ex)
+				{
+					_logger.Warning(ex, "Failed to poll Twitch viewer counts");
+					await Task.Delay(VIEW_COUNT_POLL_INTERVAL, cancellationToken).ConfigureAwait(false);
+				}
+			}
+		}
+
+		private async Task PollViewCountsOnce(CancellationToken cancellationToken)
+		{
+			if (_viewCountCallbackRegistrations.IsEmpty)
+			{
+				return;
+			}
+
+			var channelIds = _channelSubscriptionIds.Keys.ToArray();
+			if (channelIds.Length == 0)
+			{
+				return;
+			}
+
+			var serverTimeRaw = ToLegacyServerTimeRaw(DateTimeOffset.UtcNow);
+			for (var offset = 0; offset < channelIds.Length; offset += HELIX_USER_IDS_PER_REQUEST_LIMIT)
+			{
+				cancellationToken.ThrowIfCancellationRequested();
+
+				var chunkSize = Math.Min(HELIX_USER_IDS_PER_REQUEST_LIMIT, channelIds.Length - offset);
+				var userIds = new string[chunkSize];
+				Array.Copy(channelIds, offset, userIds, 0, chunkSize);
+
+				var streamResponse = await _twitchHelixApiService.GetStreams(userIds: userIds, cancellationToken: cancellationToken).ConfigureAwait(false);
+				if (streamResponse == null)
+				{
+					continue;
+				}
+
+				foreach (var stream in streamResponse.Value.Data)
+				{
+					var viewCountUpdate = new ViewCountUpdate(serverTimeRaw, stream.ViewerCount);
+					foreach (var callback in _viewCountCallbackRegistrations.Keys)
+					{
+						callback(stream.UserId, viewCountUpdate);
+					}
+				}
+			}
 		}
 
 		private async Task UnsubscribeFromChannelInternal(string channelId)

--- a/CatCore/Services/Twitch/TwitchEventSubChatService.cs
+++ b/CatCore/Services/Twitch/TwitchEventSubChatService.cs
@@ -388,12 +388,20 @@ namespace CatCore.Services.Twitch
 					(uint)(ev.Cheer?.Bits ?? 0)
 				);
 
+				// Determine if the logged-in user is mentioned
+				var isMentioned = false;
+				if (_loggedInUser != null && !string.IsNullOrEmpty(ev.Message.Text))
+				{
+					var mention = "@" + _loggedInUser.Value.LoginName;
+					isMentioned = ev.Message.Text.IndexOf(mention, StringComparison.OrdinalIgnoreCase) >= 0;
+				}
+
 				// Build TwitchMessage
 				var twitchMessage = new TwitchMessage(
 					ev.MessageId,
 					false,
 					ev.MessageType == "ACTION",
-					ev.Message.Text.Contains($"@{_loggedInUser?.LoginName}"),
+					isMentioned,
 					ev.Message.Text,
 					user,
 					channel,
@@ -483,7 +491,7 @@ namespace CatCore.Services.Twitch
 			}
 			catch (Exception ex)
 			{
-				_logger.Warning(ex, "Failed to handle channel.chat.message.delete");
+				_logger.Warning(ex, "Failed to handle channel.chat.message_delete");
 			}
 		}
 
@@ -520,26 +528,16 @@ namespace CatCore.Services.Twitch
 
 				// Build IRC-equivalent tags dictionary
 				var tags = new Dictionary<string, string>();
-				if (ev.EmoteMode)
-				{
-					tags[IrcMessageTags.EMOTE_ONLY] = "1";
-				}
-				if (ev.FollowerMode)
-				{
-					tags[IrcMessageTags.FOLLOWERS_ONLY] = ev.FollowerModeDurationMinutes.ToString();
-				}
-				if (ev.SubscriberMode)
-				{
-					tags[IrcMessageTags.SUBS_ONLY] = "1";
-				}
-				if (ev.UniqueChatMode)
-				{
-					tags[IrcMessageTags.R9_K] = "1";
-				}
-				if (ev.SlowMode)
-				{
-					tags[IrcMessageTags.SLOW] = ev.SlowModeWaitSeconds.ToString();
-				}
+				// Populate tags for both enabled and disabled states so room state transitions correctly.
+				tags[IrcMessageTags.EMOTE_ONLY] = ev.EmoteMode ? "1" : "0";
+				tags[IrcMessageTags.FOLLOWERS_ONLY] = ev.FollowerMode
+					? ev.FollowerModeDurationMinutes.ToString()
+					: "-1";
+				tags[IrcMessageTags.SUBS_ONLY] = ev.SubscriberMode ? "1" : "0";
+				tags[IrcMessageTags.R9_K] = ev.UniqueChatMode ? "1" : "0";
+				tags[IrcMessageTags.SLOW] = ev.SlowMode
+					? ev.SlowModeWaitSeconds.ToString()
+					: "0";
 
 				var roomStateDict = new ReadOnlyDictionary<string, string>(tags);
 				_roomStateTrackerService.UpdateRoomState(ev.BroadcasterUserLogin, roomStateDict);
@@ -565,10 +563,17 @@ namespace CatCore.Services.Twitch
 				return;
 			}
 
+			var activeChannels = _twitchChannelManagementService.GetAllActiveChannelsAsDictionary();
 			var channelIds = _twitchChannelManagementService.GetAllActiveChannelIds();
 			foreach (var channelId in channelIds)
 			{
-				await SubscribeToChannelInternal(channelId, _twitchChannelManagementService.GetAllActiveChannelsAsDictionary()[channelId]).ConfigureAwait(false);
+				if (!activeChannels.TryGetValue(channelId, out var channelName))
+				{
+					_logger.Warning("Active channel dictionary missing entry for channel ID {ChannelId} while subscribing to all channels.", channelId);
+					continue;
+				}
+
+				await SubscribeToChannelInternal(channelId, channelName).ConfigureAwait(false);
 			}
 		}
 
@@ -609,6 +614,15 @@ namespace CatCore.Services.Twitch
 
 			if (subscriptionIds.Count > 0)
 			{
+				// Delete any existing subscriptions for this channel before replacing to avoid leaks.
+				if (_channelSubscriptionIds.TryRemove(channelId, out var existingSubscriptionIds))
+				{
+					foreach (var existingId in existingSubscriptionIds)
+					{
+						await _twitchHelixApiService.DeleteEventSubSubscription(existingId).ConfigureAwait(false);
+					}
+				}
+
 				_channelSubscriptionIds[channelId] = subscriptionIds;
 				OnJoinChannel?.Invoke(new TwitchChannel(this, channelId, channelName));
 			}

--- a/CatCore/Services/Twitch/TwitchHelixApiService.EventSub.cs
+++ b/CatCore/Services/Twitch/TwitchHelixApiService.EventSub.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using CatCore.Exceptions;
+using CatCore.Helpers.JSON;
+using CatCore.Models.Twitch.Helix.Requests;
+using CatCore.Models.Twitch.Helix.Responses;
+using Serilog;
+
+namespace CatCore.Services.Twitch
+{
+	public sealed partial class TwitchHelixApiService
+	{
+		/// <summary>
+		/// Sends a chat message to a broadcaster's chat.
+		/// </summary>
+		/// <param name="broadcasterId">The ID of the broadcaster whose chat you want to send a message to</param>
+		/// <param name="senderUserId">The ID of the user sending the message</param>
+		/// <param name="message">The message text. Max length is 500 characters</param>
+		/// <param name="cancellationToken">CancellationToken that can be used to cancel the call</param>
+		/// <returns>True if the message was sent successfully, false otherwise</returns>
+		/// <exception cref="TwitchNotAuthenticatedException">Gets thrown when the user isn't authenticated</exception>
+		internal async Task<bool> SendChatMessage(string broadcasterId, string senderUserId, string message, CancellationToken cancellationToken = default)
+		{
+			await CheckUserLoggedIn().ConfigureAwait(false);
+
+			if (message.Length > 500)
+			{
+				_logger.Warning("Message length exceeds 500 characters. Trimming to 500");
+				message = message.Substring(0, 500);
+			}
+
+			var requestDto = new SendChatMessageRequestDto
+			{
+				BroadcasterId = broadcasterId,
+				SenderId = senderUserId,
+				Message = message
+			};
+
+			var url = $"chat/messages";
+			try
+			{
+				var jsonContent = JsonSerializer.Serialize(requestDto, TwitchHelixSerializerContext.Default.SendChatMessageRequestDto);
+				using var content = new StringContent(jsonContent, System.Text.Encoding.UTF8, "application/json");
+				using var response = await _combinedHelixPolicy.ExecuteAsync(async ct =>
+					await _helixClient.PostAsync(url, content, ct).ConfigureAwait(false), cancellationToken).ConfigureAwait(false);
+
+				return response?.IsSuccessStatusCode ?? false;
+			}
+			catch (Exception ex)
+			{
+				_logger.Warning(ex, "Failed to send chat message");
+				return false;
+			}
+		}
+
+		/// <summary>
+		/// Creates an EventSub subscription for receiving real-time events.
+		/// </summary>
+		/// <param name="type">The subscription type (e.g., "channel.chat.message")</param>
+		/// <param name="version">The subscription version (typically "1")</param>
+		/// <param name="condition">Dictionary of condition parameters (e.g., {"broadcaster_user_id": "123"})</param>
+		/// <param name="sessionId">The WebSocket session ID to receive events on</param>
+		/// <param name="cancellationToken">CancellationToken that can be used to cancel the call</param>
+		/// <returns>The subscription ID if successful, null otherwise</returns>
+		internal async Task<string?> CreateEventSubSubscription(string type, string version, Dictionary<string, string> condition, string sessionId, CancellationToken cancellationToken = default)
+		{
+			if (!_twitchAuthService.HasTokens)
+			{
+				_logger.Warning("Token not valid. Either the user is not logged in or the token has been revoked");
+				return null;
+			}
+
+			if (!_twitchAuthService.TokenIsValid && !await _twitchAuthService.RefreshTokens().ConfigureAwait(false))
+			{
+				return null;
+			}
+
+			var requestDto = new EventSubSubscriptionRequestDto
+			{
+				Type = type,
+				Version = version,
+				Condition = condition,
+				Transport = new EventSubTransportDto
+				{
+					Method = "websocket",
+					SessionId = sessionId
+				}
+			};
+
+			var url = "eventsub/subscriptions";
+
+#if DEBUG
+			_logger.Verbose("Creating EventSub subscription: Type={Type}, Version={Version}, Condition={Condition}", type, version, string.Join(", ", condition.Select(kvp => $"{kvp.Key}={kvp.Value}")));
+#endif
+
+			try
+			{
+				using var httpResponseMessage = await _combinedHelixPolicy.ExecuteAsync(async ct =>
+				{
+					var jsonContent = JsonSerializer.Serialize(requestDto, TwitchHelixSerializerContext.Default.EventSubSubscriptionRequestDto);
+					var content = new StringContent(jsonContent, System.Text.Encoding.UTF8, "application/json");
+					using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, url) { Content = content };
+					return await _helixClient.SendAsync(httpRequestMessage, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
+				}, cancellationToken).ConfigureAwait(false);
+
+				if (httpResponseMessage == null)
+				{
+					return null;
+				}
+
+				if (!httpResponseMessage.IsSuccessStatusCode)
+				{
+					var errorContent = await httpResponseMessage.Content.ReadAsStringAsync().ConfigureAwait(false);
+					_logger.Warning("Failed to create EventSub subscription. Type={Type}, StatusCode={StatusCode}, Response={Response}", type, httpResponseMessage.StatusCode, errorContent);
+					return null;
+				}
+
+				var responseJson = await httpResponseMessage.Content.ReadAsStringAsync().ConfigureAwait(false);
+				var response = JsonSerializer.Deserialize(responseJson, TwitchHelixSerializerContext.Default.EventSubSubscriptionResponseDto);
+
+				if (response == null)
+				{
+					_logger.Warning("Failed to deserialize EventSub subscription response. Type={Type}, Payload={Payload}", type, responseJson);
+					return null;
+				}
+
+				if (response.Data != null && response.Data.Count > 0)
+				{
+					var subscriptionId = response.Data[0].Id;
+					_logger.Information("EventSub subscription created successfully. ID: {SubscriptionId}", subscriptionId);
+					return subscriptionId;
+				}
+
+				_logger.Warning("EventSub subscription response did not include data. Type={Type}, Payload={Payload}", type, responseJson);
+
+				return null;
+			}
+			catch (Exception ex)
+			{
+				_logger.Warning(ex, "Failed to create EventSub subscription");
+				return null;
+			}
+		}
+
+		/// <summary>
+		/// Deletes an EventSub subscription.
+		/// </summary>
+		/// <param name="subscriptionId">The subscription ID to delete</param>
+		/// <param name="cancellationToken">CancellationToken that can be used to cancel the call</param>
+		/// <returns>True if deletion was successful, false otherwise</returns>
+		internal async Task<bool> DeleteEventSubSubscription(string subscriptionId, CancellationToken cancellationToken = default)
+		{
+			if (!_twitchAuthService.HasTokens)
+			{
+				_logger.Warning("Token not valid. Either the user is not logged in or the token has been revoked");
+				return false;
+			}
+
+			if (!_twitchAuthService.TokenIsValid && !await _twitchAuthService.RefreshTokens().ConfigureAwait(false))
+			{
+				return false;
+			}
+
+			var url = $"eventsub/subscriptions?id={Uri.EscapeDataString(subscriptionId)}";
+
+#if DEBUG
+			_logger.Verbose("Deleting EventSub subscription: {SubscriptionId}", subscriptionId);
+#endif
+
+			_logger.Warning("DeleteEventSubSubscription: Not fully implemented. Placeholder only.");
+			return false;
+		}
+	}
+}

--- a/CatCore/Services/Twitch/TwitchHelixApiService.EventSub.cs
+++ b/CatCore/Services/Twitch/TwitchHelixApiService.EventSub.cs
@@ -172,8 +172,35 @@ namespace CatCore.Services.Twitch
 			_logger.Verbose("Deleting EventSub subscription: {SubscriptionId}", subscriptionId);
 #endif
 
-			_logger.Warning("DeleteEventSubSubscription: Not fully implemented. Placeholder only.");
-			return false;
+			try
+			{
+				using var httpResponseMessage = await _combinedHelixPolicy.ExecuteAsync(async ct =>
+				{
+					using var httpRequestMessage = new HttpRequestMessage(HttpMethod.Delete, url);
+					return await _helixClient.SendAsync(httpRequestMessage, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
+				}, cancellationToken).ConfigureAwait(false);
+
+				if (httpResponseMessage == null)
+				{
+					_logger.Warning("Failed to delete EventSub subscription {SubscriptionId}: received null HTTP response", subscriptionId);
+					return false;
+				}
+
+				if (!httpResponseMessage.IsSuccessStatusCode)
+				{
+					var errorContent = await httpResponseMessage.Content.ReadAsStringAsync().ConfigureAwait(false);
+					_logger.Warning("Failed to delete EventSub subscription {SubscriptionId}. StatusCode={StatusCode}, Response={Response}", subscriptionId, httpResponseMessage.StatusCode, errorContent);
+					return false;
+				}
+
+				_logger.Information("EventSub subscription deleted successfully. ID: {SubscriptionId}", subscriptionId);
+				return true;
+			}
+			catch (Exception ex)
+			{
+				_logger.Warning(ex, "Failed to delete EventSub subscription {SubscriptionId}", subscriptionId);
+				return false;
+			}
 		}
 	}
 }

--- a/CatCore/Services/Twitch/TwitchHelixApiService.EventSub.cs
+++ b/CatCore/Services/Twitch/TwitchHelixApiService.EventSub.cs
@@ -123,7 +123,7 @@ namespace CatCore.Services.Twitch
 				var responseJson = await httpResponseMessage.Content.ReadAsStringAsync().ConfigureAwait(false);
 				var response = JsonSerializer.Deserialize(responseJson, TwitchHelixSerializerContext.Default.EventSubSubscriptionResponseDto);
 
-				if (response == null)
+				if (EqualityComparer<EventSubSubscriptionResponseDto>.Default.Equals(response, default))
 				{
 					_logger.Warning("Failed to deserialize EventSub subscription response. Type={Type}, Payload={Payload}", type, responseJson);
 					return null;

--- a/CatCore/Services/Twitch/TwitchIrcService.cs
+++ b/CatCore/Services/Twitch/TwitchIrcService.cs
@@ -19,6 +19,7 @@ using Serilog;
 
 namespace CatCore.Services.Twitch
 {
+	[Obsolete("Legacy IRC transport is deprecated. Use EventSub via ITwitchIrcService registration.")]
 	internal sealed class TwitchIrcService : ITwitchIrcService
 	{
 		private const string TWITCH_IRC_ENDPOINT = "wss://irc-ws.chat.twitch.tv:443";

--- a/CatCore/Services/Twitch/TwitchIrcService.cs
+++ b/CatCore/Services/Twitch/TwitchIrcService.cs
@@ -19,7 +19,7 @@ using Serilog;
 
 namespace CatCore.Services.Twitch
 {
-	[Obsolete("Legacy IRC transport is deprecated. Use EventSub via ITwitchIrcService registration.")]
+	[Obsolete("Legacy IRC transport is deprecated. Use the EventSub chat service (TwitchEventSubChatService) via ITwitchIrcService registration.")]
 	internal sealed class TwitchIrcService : ITwitchIrcService
 	{
 		private const string TWITCH_IRC_ENDPOINT = "wss://irc-ws.chat.twitch.tv:443";

--- a/CatCore/Services/Twitch/TwitchService.cs
+++ b/CatCore/Services/Twitch/TwitchService.cs
@@ -35,6 +35,7 @@ namespace CatCore.Services.Twitch
 		}
 
 		/// <inheritdoc />
+		[Obsolete("Twitch Legacy PubSub was decommissioned. Migrate to EventSub-based APIs.")]
 		public ITwitchPubSubServiceManager GetPubSubService() => _twitchPubSubServiceManager;
 
 		/// <inheritdoc />


### PR DESCRIPTION
Migrates Twitch chat transport from the legacy IRC WebSocket to Twitch EventSub WebSocket, adding Helix helpers for sending chat messages and creating/deleting EventSub subscriptions, plus new EventSub payload models/serialization.

## Changes Made

- **EventSub chat service**: Implemented `TwitchEventSubChatService` as the new `ITwitchIrcService` backend; deprecated `TwitchIrcService` (legacy IRC transport) with an explicit obsolete message pointing to `TwitchEventSubChatService`
- **Helix API**: Added helpers for sending chat messages and creating/deleting EventSub subscriptions with correct HTTP DELETE implementation
- **EventSub subscription management**: Subscriptions are now replaced only when all requested types succeed; partial failures trigger a rollback to avoid leaking subscriptions. Existing subscriptions are deleted before replacement on reconnect
- **Session reconnect**: `HandleSessionReconnect` now correctly establishes a new connection to the provided reconnect URL before dropping the old one, following EventSub WebSocket reconnect semantics. `DisconnectHappenedHandler` no longer unconditionally clears `_reconnectUrl`
- **Room state**: Chat settings updates now always populate tags for both enabled and disabled modes so `TwitchRoomStateTrackerService` correctly clears previous values on mode changes
- **Emote detection**: Fixed position tracking in `ExtractEmoteInfoFromFragments` (running offset for duplicate emote text) and `ExtractOtherEmotesFromText` (search starts from fragment's position); all `IndexOf` calls use `StringComparison.Ordinal` for deterministic, culture-independent index calculation
- **Message mentions**: `isMentioned` is now guarded against a null `_loggedInUser` and uses `OrdinalIgnoreCase` comparison
- **DTOs**: Moved `EventSubSubscriptionResponseDto`/`EventSubSubscriptionInfoDto` to the `Responses` namespace; converted to `readonly struct` + `[JsonConstructor]` pattern with null-safe initialization, consistent with existing Helix response DTOs
- **Performance**: Metadata is now deserialized directly from the existing `JsonElement`, eliminating an unnecessary `JsonDocument` allocation per message
- **Build**: Pinned `LangVersion` to `11.0` for deterministic builds