### PR TITLE
Remove unused EventSub chat scopes and update authorization logging

### DIFF
--- a/CatCore/CatCore.csproj
+++ b/CatCore/CatCore.csproj
@@ -24,7 +24,7 @@
 		<Title>CatCore</Title>
 		<Description>CatCore is a .NET Standard 2.0 library which provides a shared connection to mods and other applications for Twitch (and other future streaming platforms).</Description>
 		<Authors>Eris</Authors>
-		<Version>1.1.1-alpha6</Version>
+		<Version>1.1.1-alpha7</Version>
 		<Copyright>Copyright © Eris 2023</Copyright>
 		<PackageProjectUrl>https://github.com/ErisApps/CatCore</PackageProjectUrl>
 	</PropertyGroup>

--- a/CatCore/Services/Twitch/TwitchAuthService.cs
+++ b/CatCore/Services/Twitch/TwitchAuthService.cs
@@ -58,13 +58,6 @@ namespace CatCore.Services.Twitch
 			"user:read:follows"
 		};
 
-		private static readonly string[] _requiredEventSubChatScopes =
-		{
-			"user:read:chat",
-			"user:bot",
-			"channel:bot"
-		};
-
 		private readonly ILogger _logger;
 		private readonly ConstantsBase _constants;
 		private readonly HttpClient _twitchAuthClient;
@@ -430,7 +423,7 @@ namespace CatCore.Services.Twitch
 				return null;
 			}
 
-			var missingScopes = _requiredEventSubChatScopes.Where(requiredScope => !validationResponse.Scopes.Contains(requiredScope)).ToArray();
+			var missingScopes = _twitchAuthorizationScope.Where(requiredScope => !validationResponse.Scopes.Contains(requiredScope)).ToArray();
 			if (missingScopes.Length > 0)
 			{
 				if (resetDataOnFailure)
@@ -441,7 +434,7 @@ namespace CatCore.Services.Twitch
 				}
 
 				Status = AuthenticationStatus.Unauthorized;
-				_logger.Warning("Twitch token is missing required EventSub chat scopes. Missing={MissingScopes}; Current={CurrentScopes}",
+				_logger.Warning("Twitch token is missing required authorization scopes. Missing={MissingScopes}; Current={CurrentScopes}",
 					string.Join(",", missingScopes),
 					string.Join(",", validationResponse.Scopes));
 				return null;


### PR DESCRIPTION
This pull request simplifies the handling of required authorization scopes in the `TwitchAuthService` by consolidating scope checks and cleaning up related code. The main changes focus on removing redundant scope definitions and improving the clarity of logging messages.

Authorization scope management:

* Removed the `_requiredEventSubChatScopes` array, consolidating all required scope checks to use the existing `_twitchAuthorizationScope` array instead.
* Updated the logic in `GetTokensByAuthorizationCode` to check for missing scopes using `_twitchAuthorizationScope` instead of the removed `_requiredEventSubChatScopes`.

Logging improvements:

* Changed the warning log message to refer to "required authorization scopes" instead of "required EventSub chat scopes" for improved clarity.…ization scopes